### PR TITLE
Fix reversed image WrapperElement logic

### DIFF
--- a/components/image/image.js
+++ b/components/image/image.js
@@ -38,7 +38,7 @@ class Image extends Component {
     const paddingPercentage = aspectRatio ?
       { paddingBottom: `${aspectRatio * 100}%` } :
       null;
-    const WrapperElement = caption ? Fragment : 'figure';
+    const WrapperElement = caption ? 'figure' : Fragment;
     // Set up image element(s) for maybe using with lazyload component
     const imageContent = (
       <Fragment>


### PR DESCRIPTION
If we have a caption we should use `<figure>`, otherwise `<Fragment>`, not the reverse.