### PR TITLE
Views fix

### DIFF
--- a/packages/core/cli/start.js
+++ b/packages/core/cli/start.js
@@ -25,7 +25,6 @@ app.get('/bust-entire-cache', bustCache);
 app.purge('/*', purgePageCache);
 
 // Set view engine.
-app.set('views', '/');
 app.set('view engine', 'ejs');
 
 // Run all customize server functions.

--- a/packages/core/config/paths.js
+++ b/packages/core/config/paths.js
@@ -11,15 +11,19 @@ const {
   BUILD_CONTEXT,
 } = process.env;
 
-// Root of user app and root of irving core.
-const appRoot = APP_ROOT || fs.realpathSync(process.cwd());
-const irvingRoot = fs.realpathSync(
-  path.join(__dirname, '../')
-);
-
 // Used for webpack `context` config value. Useful to configure if app is built in a
 // different location from where it is run.
 const buildContext = BUILD_CONTEXT || fs.realpathSync(process.cwd());
+
+// Root of user app and root of irving core.
+const appRoot = APP_ROOT || fs.realpathSync(process.cwd());
+const irvingRoot = path.join(__dirname, '../');
+
+// Path to irving core relative to the appRoot.
+const appIrvingRoot = path.join(
+  appRoot,
+  path.relative(buildContext, irvingRoot)
+);
 
 /**
  * Ensure irving paths are consistent regardless of the processes' current
@@ -54,6 +58,7 @@ const resolveBuildDir = (relativePath) => (
 module.exports = {
   appRoot,
   irvingRoot,
+  appIrvingRoot,
   buildContext,
   clientRoot: resolveIrvingDir('client'),
   serverRoot: resolveIrvingDir('server/serverRenderer.js'),

--- a/packages/core/config/webpack/rules.js
+++ b/packages/core/config/webpack/rules.js
@@ -4,7 +4,7 @@ const {
   buildContext,
   irvingRoot,
 } = require('../paths');
-const { maybeResolveUserModule } = require('../../utils/userModule');
+const { maybeResolveBuildModule } = require('../../utils/userModule');
 
 const include = (filepath) => {
   const matches = (
@@ -47,7 +47,7 @@ module.exports = function getRules(context) {
         {
           loader: 'eslint-loader',
           options: {
-            configFile: maybeResolveUserModule('.eslintrc.js'),
+            configFile: maybeResolveBuildModule('.eslintrc.js'),
           },
         },
       ],

--- a/packages/core/utils/userModule.js
+++ b/packages/core/utils/userModule.js
@@ -4,9 +4,28 @@ const {
   appRoot,
   buildContext,
   appIrvingRoot,
+  irvingRoot,
 } = require('../config/paths');
 
 /* eslint-disable import/no-dynamic-require, global-require */
+/**
+ * Resolve the path to a user module, falling back to Irving core version.
+ *
+ * @param {string} userPath Path to user-defined module, relative to user app root.
+ * @param {string} corePath Path to Irving core module, relative to Irving core root, if different from user path.
+ */
+module.exports.maybeResolveBuildModule = (userPath, corePath) => {
+  const defaultPath = corePath || userPath;
+
+  // Resolve file relative to build context if it exists.
+  if (fs.existsSync(path.resolve(buildContext, userPath))) {
+    return path.resolve(buildContext, userPath);
+  }
+
+  // Resolve file relative to irving app in build context otherwise.
+  return path.resolve(irvingRoot, defaultPath);
+};
+
 /**
  * Resolve the path to a user module, falling back to Irving core version.
  *

--- a/packages/core/utils/userModule.js
+++ b/packages/core/utils/userModule.js
@@ -1,6 +1,10 @@
 const fs = require('fs');
 const path = require('path');
-const { appRoot, irvingRoot } = require('../config/paths');
+const {
+  appRoot,
+  buildContext,
+  appIrvingRoot,
+} = require('../config/paths');
 
 /* eslint-disable import/no-dynamic-require, global-require */
 /**
@@ -12,11 +16,14 @@ const { appRoot, irvingRoot } = require('../config/paths');
 const maybeResolveUserModule = (userPath, corePath) => {
   const defaultPath = corePath || userPath;
 
-  if (fs.existsSync(path.resolve(appRoot, userPath))) {
+  // If file exists in build context, assume the same file exists in the appRoot.
+  // This will support app finding appropriate file if build happens in a different place than app execution.
+  if (fs.existsSync(path.resolve(buildContext, userPath))) {
     return path.resolve(appRoot, userPath);
   }
 
-  return path.resolve(irvingRoot, defaultPath);
+  // Use path to irving core relative to app root otherwise.
+  return path.resolve(appIrvingRoot, defaultPath);
 };
 
 module.exports.maybeResolveUserModule = maybeResolveUserModule;

--- a/packages/core/utils/userModule.js
+++ b/packages/core/utils/userModule.js
@@ -9,10 +9,10 @@ const {
 
 /* eslint-disable import/no-dynamic-require, global-require */
 /**
- * Resolve the path to a user module, falling back to Irving core version.
+ * Resolve the path to a module required in the build, fall back to irving core.
  *
- * @param {string} userPath Path to user-defined module, relative to user app root.
- * @param {string} corePath Path to Irving core module, relative to Irving core root, if different from user path.
+ * @param {string} userPath Path to user-defined module.
+ * @param {string} corePath Path to Irving core module, if different from user path.
  */
 module.exports.maybeResolveBuildModule = (userPath, corePath) => {
   const defaultPath = corePath || userPath;


### PR DESCRIPTION
Fix for issue finding views in built files.

Fixes:
* Initially we were checking to see if a file exists in the `appRoot` before resolving/requiring the file. However, if the `appRoot` is different from the `buildContext`, the file will intentionally not exists. Therefore, we're going to check the `buildContext` for the file first and assume it will also exist at the same path relative to `appRoot`.
* We also need a function that will resolve a file relative to the `buildContext` only. Thus far only for `eslintrc.js`.

Merging away pre-review.