### PR TITLE
IRV-255 Add specific packages to the `includes` variable in webpack rules config

### DIFF
--- a/packages/core/config/webpack/rules.js
+++ b/packages/core/config/webpack/rules.js
@@ -20,7 +20,17 @@ const include = (filepath) => {
       ) ||
       // Anything imported within irving packages should be included in build,
       // even if located within node_modules (but not nested node modules).
-      filepath.match(/node_modules\/@irvingjs\/[^/]*\/(?!node_modules)/)
+      filepath.match(/node_modules\/@irvingjs\/[^/]*\/(?!node_modules)/) ||
+      // These specific node modules, which contain arrow functions that must be
+      // transpiled.
+      (
+        filepath.includes('node_modules') &&
+        (
+          filepath.includes('query-string') ||
+          filepath.includes('split-on-first') ||
+          filepath.includes('strict-uri-encode')
+        )
+      )
     ) &&
     // Exclude minified JS.
     ! filepath.match(/\.min\.js$/)


### PR DESCRIPTION
These packages, which are included in Irving core, contain arrow functions, which must be transpiled with babel to avoid cross browser issues.

ticket: https://alleyinteractive.atlassian.net/browse/IRV-255