### PR TITLE
Do not encode query string

### DIFF
--- a/packages/core/services/fetchComponents.js
+++ b/packages/core/services/fetchComponents.js
@@ -49,6 +49,9 @@ export async function fetchComponents(
     ...getExtraQueryParams(),
     ...queryString.parse(search),
     ...cookie,
+  },
+  {
+    encode: false,
   });
   const apiUrl = `${process.env.API_ROOT_URL}/components?${query}`;
 


### PR DESCRIPTION
This makes the URL more readable and aids in ensuring the URL purged by Varnish on VIP Go exactly matches the URL requested by Irving (in order to properly bust the cache when a post is updated)