### PR TITLE
Add publicPath: '/' to url-loader config

### DIFF
--- a/packages/core/config/webpack/rules.js
+++ b/packages/core/config/webpack/rules.js
@@ -101,6 +101,7 @@ module.exports = function getRules(context) {
         {
           loader: 'url-loader',
           options: {
+            publicPath: '/',
             limit: 10000,
             emitFile: ! isServer,
             name: 'static/media/[name].[hash:8].[ext]',


### PR DESCRIPTION
This update adds `publicPath: '/'` to the url-loader config options, which fixes an issue with loading static assets in CSS with `url()`.