### PR TITLE
Modifications to get npm link working locally

### DIFF
--- a/packages/core/config/webpack.config.js
+++ b/packages/core/config/webpack.config.js
@@ -17,6 +17,7 @@ module.exports = (env, argv) => {
       resolve: {
         extensions,
         alias: client.getAlias(),
+        symlinks: ! isProd,
       },
       devtool: client.getDevTool(),
       entry: client.getEntry(),
@@ -42,6 +43,7 @@ module.exports = (env, argv) => {
       resolve: {
         extensions,
         alias: server.getAlias(),
+        symlinks: ! isProd,
       },
       // Quiet bundle size errors, as they are not applicable for code executed in NodeJS.
       performance: {

--- a/packages/core/config/webpack/rules.js
+++ b/packages/core/config/webpack/rules.js
@@ -20,17 +20,7 @@ const include = (filepath) => {
       ) ||
       // Anything imported within irving packages should be included in build,
       // even if located within node_modules (but not nested node modules).
-      filepath.match(/node_modules\/@irvingjs\/[^/]*\/(?!node_modules)/) ||
-      // These specific node modules, which contain arrow functions that must be
-      // transpiled.
-      (
-        filepath.includes('node_modules') &&
-        (
-          filepath.includes('query-string') ||
-          filepath.includes('split-on-first') ||
-          filepath.includes('strict-uri-encode')
-        )
-      )
+      filepath.match(/node_modules\/@irvingjs\/[^/]*\/(?!node_modules)/)
     ) &&
     // Exclude minified JS.
     ! filepath.match(/\.min\.js$/)
@@ -114,8 +104,22 @@ module.exports = function getRules(context) {
       use: ['svg-react-loader'],
     },
     {
-      test: /\.jsx?$/,
-      include,
+      resource: {
+        test: /\.jsx?$/,
+        or: [
+          include,
+          (filepath) => (
+            // These specific node modules, which contain arrow functions that must be
+            // transpiled.
+            filepath.includes('node_modules') &&
+              (
+                filepath.includes('query-string') ||
+                filepath.includes('split-on-first') ||
+                filepath.includes('strict-uri-encode')
+              )
+          ),
+        ],
+      },
       use: [
         {
           loader: 'babel-loader',


### PR DESCRIPTION
* Modify symlink behavior for local dev
* Move the block that picks out the node modules with arrow functions from the main test down to the `babel-loader` section, so that those 3 node modules _do_ get transpiled by Babel, but _do not_ get linted