### PR TITLE
Add sourceType to babel config

### DIFF
--- a/packages/babel-preset-irving/index.js
+++ b/packages/babel-preset-irving/index.js
@@ -1,5 +1,6 @@
 module.exports = function babelPresetIrving() {
   return {
+    sourceType: 'unambiguous',
     plugins: [
       'lodash',
       'react-hot-loader/babel',


### PR DESCRIPTION
'unambiguous' setting will allow mixing CommonJS and es modules. no clue why babel hasn't complained about this before.