### PR TITLE
Bug - grid fallbacks columns calculation

### DIFF
--- a/packages/styled/components/grid/container.js
+++ b/packages/styled/components/grid/container.js
@@ -21,7 +21,7 @@ const GridContainer = (props) => {
     maxWidth,
     tag,
   } = props;
-  const useProps = (gridColumns && gridGap);
+  const useProps = !! (gridColumns || gridGap);
 
   return (
     <StyledContainer
@@ -37,9 +37,9 @@ const GridContainer = (props) => {
       {useProps ? (
         <GridContext.Provider
           value={{
-            gridColumns,
-            gridRows,
-            gridGap,
+            gridColumns: gridColumns || contextColumns,
+            gridRows: gridRows || contextRows,
+            gridGap: gridGap || contextGap,
           }}
         >
           {children}

--- a/packages/styled/utils/cssGrid.js
+++ b/packages/styled/utils/cssGrid.js
@@ -52,17 +52,27 @@ export const rowsCustom = (rows) => css`
 
 /**
  * A mixin for generating CSS grid span styles, with flexbox fallback for IE.
- * @param {array|string} columns the grid-column start and end values,
+ * @param {array|string} columns the grid-column start and end values, per CSS Grid spec, ie. [1, 4]
  * @param {number} gridColumns the number of columns set on the container element
  * @param {number|array} gridGap the grid-gap set on the container element
- * per CSS Grid spec, ie. [1, 4]
  */
 export const columnSpan = (columns, gridColumns, gridGap) => {
+  // Convert columns value to grid-column value.
   const gridColumnSpan = 'auto' === columns ? 'auto' : columns.join(' / ');
 
-  const flexboxWidth = 'auto' === columns ? (1 / gridColumns) * 100 :
-    (columns.reverse().reduce((acc, curr) => acc - curr) / gridColumns) * 100;
+  // Calculate flexbox column width based on grid columns.
+  let flexboxWidth = 0;
+  if ('auto' === columns) {
+    flexboxWidth = (1 / gridColumns) * 100;
+  }
 
+  if (Array.isArray(columns)) {
+    flexboxWidth = Math.abs(
+      (columns.reverse().reduce((acc, curr) => acc - curr) / gridColumns) * 100
+    );
+  }
+
+  // Calculate flexbox padding based on grid gap.
   let flexboxPadding = 0;
   if ('number' === typeof gridGap) {
     flexboxPadding = rem(gridGap / 2);


### PR DESCRIPTION
This update fixes a couple of things missed in the last PR (#158):
- In some cases and for reasons I still don't understand, the flexbox width values calculated in the `columnSpan` function were negative.
- I also added some more explicit checking to that the width calculations only work for numbers and arrays, to reduce the possibility of errors.
- Child `GridCell` components were not receiving `gridColumns` values set on the parent as expected, but only ever getting the value set in the top level GridContext provider.