### PR TITLE
Update features for default loading component

### DIFF
--- a/packages/core/components/helpers/defaultLoading/defaultLoading.css
+++ b/packages/core/components/helpers/defaultLoading/defaultLoading.css
@@ -2,8 +2,7 @@
   align-items: center;
   display: flex;
   justify-content: center;
-  min-height: 100vh;
-  padding: 2rem;
+  padding: 4rem;
 }
 
 .fullScreen {

--- a/packages/core/components/helpers/defaultLoading/defaultLoading.css
+++ b/packages/core/components/helpers/defaultLoading/defaultLoading.css
@@ -2,6 +2,7 @@
   align-items: center;
   display: flex;
   justify-content: center;
+  min-height: 100vh;
   padding: 2rem;
 }
 
@@ -9,4 +10,5 @@
   height: 100%;
   position: fixed;
   width: 100%;
+  z-index: 1000;
 }

--- a/packages/core/components/helpers/defaultLoading/index.js
+++ b/packages/core/components/helpers/defaultLoading/index.js
@@ -6,9 +6,10 @@ import styles from './defaultLoading.css';
 
 const DefaultLoading = (props) => {
   const {
+    className,
     fullScreen,
     fullScreenBgColor,
-    loadingComponent,
+    children,
     spinnerProps,
   } = props;
 
@@ -16,25 +17,32 @@ const DefaultLoading = (props) => {
     <div
       className={classNames(
         styles.wrapper,
+        className,
         {
           [styles.fullScreen]: fullScreen,
         }
       )}
       style={{ backgroundColor: fullScreenBgColor }}
     >
-      {loadingComponent || <Spinner {...spinnerProps} />}
+      {children || <Spinner {...spinnerProps} />}
     </div>
   );
 };
 
 DefaultLoading.defaultProps = {
+  className: '',
   fullScreen: false,
   fullScreenBgColor: '#FFF',
-  loadingComponent: null,
+  children: false,
   spinnerProps: {},
 };
 
 DefaultLoading.propTypes = {
+  /**
+   * Additional classname to add to loading component wrapper.
+   * default: ''
+   */
+  className: PropTypes.string,
   /**
    * Whether or not the loader component should cover the entire screen.
    * default: false
@@ -49,7 +57,11 @@ DefaultLoading.propTypes = {
    * Allows for defining a custom component to be displayed for the loading state.
    * default: null (<Spinner />)
    */
-  loadingComponent: PropTypes.element,
+  children: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   /**
    * Custom props to pass to the <Spinner /> component.
    * default: {},

--- a/packages/core/components/hoc/withAsync.js
+++ b/packages/core/components/hoc/withAsync.js
@@ -1,9 +1,9 @@
 import universal from 'react-universal-component';
-import PlaceholderLoading from 'components/placeholderLoading';
+import DefaultLoading from 'components/defaultLoading';
 
 const withAsync = (importer) => (
   universal(importer, {
-    loading: PlaceholderLoading,
+    loading: DefaultLoading,
     minDelay: 300,
     ignoreBabelRename: true,
   })

--- a/packages/core/components/hoc/withLoader.js
+++ b/packages/core/components/hoc/withLoader.js
@@ -6,13 +6,20 @@ import DefaultLoading from 'components/helpers/defaultLoading';
 
 /**
  * @param {*} WrappedComponent component that gets the conditional loading state
- * @param {object} loadingProps optional props passed to the DefaultLoading component
+ * @param {object} opts Options for this HOC
+ * @param {object} opts.loadingProps - Props for the default loading component
+ * @param {object} opts.LoadingComponent - Loading component to use instead of the default.
  */
-const withLoader = (WrappedComponent, loadingProps) => {
+const withLoader = (WrappedComponent, opts = {}) => {
+  const {
+    loadingProps = {},
+    LoadingComponent = DefaultLoading,
+  } = opts;
+
   const Loader = (props) => {
     const { loading } = props;
     return loading ? (
-      <DefaultLoading {...loadingProps} />
+      <LoadingComponent {...loadingProps} />
     ) : (
       <WrappedComponent {...props} />
     );

--- a/packages/core/components/readme.md
+++ b/packages/core/components/readme.md
@@ -8,5 +8,5 @@ Some noteworthy components to flag,
 * [Connected Root](https://github.com/alleyinteractive/irving/tree/production/components/connectedRoot)
 * [Error Boundary](https://github.com/alleyinteractive/irving/tree/production/components/errorBoundary)
 * [Placeholder](https://github.com/alleyinteractive/irving/tree/production/components/placeholder)
-* [Placeholder Loading](https://github.com/alleyinteractive/irving/tree/production/components/placeholderLoading)
+* [Placeholder Loading](https://github.com/alleyinteractive/irving/tree/production/components/defaultLoading)
 * [Root Providers](https://github.com/alleyinteractive/irving/tree/production/components/rootProviders)


### PR DESCRIPTION
## Issue(s): Relates to or closes...
N/A

## Summary: This pull request will...
- switch to using children for default loading component content
- add className prop to default loading component
- tweak styles for default loading component
- add option to override default loading component entirely in withLoader

## Tests: I know this code works because...
Tested in client project
