### PR TITLE
Don't run express-naked-redirect in development

### DIFF
--- a/packages/core/server/customizeRedirect.js
+++ b/packages/core/server/customizeRedirect.js
@@ -1,23 +1,30 @@
 const expressNakedRedirect = require('express-naked-redirect');
-const getConfigField = require('../utils/getConfigField');
+const { getConfigObject } = require('../utils/getConfigValue');
 const {
+  NODE_ENV,
   ROOT_URL,
 } = process.env;
 
-module.exports = function () {
-  const config = getConfigField('customizeRedirect');
+const customizeRedirect = () => {
+  const config = getConfigObject('customizeRedirect');
 
-  return function (req, res, next) {
-    // Move on if no config was added.
-    if (Object.keys(config).length === 0) {
-      return next();
-    }
-
-    // Confirm if request with the root url.
-    if (!ROOT_URL.includes(req.headers.host)) {
-      return next();
+  return (req, res, next) => {
+    /**
+     * Move on if:
+     * - no config was added
+     * - current request is not for the configured ROOT_URL
+     * - in a dev environment
+     */
+    if (
+      ! ROOT_URL.includes(req.headers.host) ||
+      0 === Object.keys(config).length ||
+      'development' === NODE_ENV
+    ) {
+      next();
     } else {
-      return expressNakedRedirect(config)(req, res, next);
+      expressNakedRedirect(config)(req, res, next);
     }
   };
 };
+
+module.exports = customizeRedirect;


### PR DESCRIPTION
## Issue(s): Relates to or closes...
N/A

## Summary: This pull request will...
* Disable `express-naked-redirect` in development
* Update `customizeRedirect` option to be a function returning an object.

## Tests: I know this code works because...
tested locally
