### PR TITLE
Base support for alias

### DIFF
--- a/packages/core/utils/toReactElement.js
+++ b/packages/core/utils/toReactElement.js
@@ -39,6 +39,7 @@ export function createComponentGroups(componentGroups) {
 export default function toReactElement(apiComponent, keyPrefix = '') {
   const {
     name,
+    alias = '',
     config,
     children,
     componentGroups = {},
@@ -60,7 +61,7 @@ export default function toReactElement(apiComponent, keyPrefix = '') {
     isString(child) ? child : toReactElement(child, String(index))
   ));
 
-  const type = getReactComponent(name);
+  const type = 0 !== alias.length ? getReactComponent(alias) : getReactComponent(name);
   const isNativeDOMElm = 'string' === typeof type;
   if (isNativeDOMElm) {
     // Strip invalid attributes for native dom elements.


### PR DESCRIPTION
## Issue(s): Relates to or closes...
Closes IRV-425.

## Summary: This pull request will...
Adds support for a new `alias` key which can be used to render a React component using a different component from the mapping.

For example, you could register a `homepage-link` component that uses the `irving/link` to render it. This allows developers to easily create variations of components that already exist, but allows for clear debugging.
```json
{
	"name": "irving/homepage-link",
	"alias": "irving/link"
}
```

## Tests: I know this code works because...
Updated tests in `toReactElement.test.js`