### PR TITLE
Rename jsonp function to prevent conflicts

### DIFF
--- a/packages/core/config/webpack/output.js
+++ b/packages/core/config/webpack/output.js
@@ -22,6 +22,7 @@ module.exports = function getOutput(context) {
         publicPath: `${rootUrl}/`,
         filename: 'static/js/[name].[chunkhash:8].bundle.js',
         chunkFilename: 'static/js/[name].[chunkhash:8].chunk.js',
+        jsonpFunction: 'irvingJsonp',
       };
 
     case 'development_client':
@@ -30,6 +31,7 @@ module.exports = function getOutput(context) {
         publicPath: `${rootUrl}/`,
         filename: '[name].bundle.js',
         chunkFilename: '[name].chunk.js',
+        jsonpFunction: 'irvingJsonp',
       };
 
     default:

--- a/packages/core/config/webpack/output.js
+++ b/packages/core/config/webpack/output.js
@@ -22,7 +22,7 @@ module.exports = function getOutput(context) {
         publicPath: `${rootUrl}/`,
         filename: 'static/js/[name].[chunkhash:8].bundle.js',
         chunkFilename: 'static/js/[name].[chunkhash:8].chunk.js',
-        jsonpFunction: 'irvingJsonp',
+        jsonpFunction: 'irvingWebpackJsonp',
       };
 
     case 'development_client':
@@ -31,7 +31,7 @@ module.exports = function getOutput(context) {
         publicPath: `${rootUrl}/`,
         filename: '[name].bundle.js',
         chunkFilename: '[name].chunk.js',
-        jsonpFunction: 'irvingJsonp',
+        jsonpFunction: 'irvingWebpackJsonp',
       };
 
     default:


### PR DESCRIPTION
Rename jsonp function to prevent conflicts with other webpack bundles

## Issue(s): Relates to or closes...
IRV-526

## Summary: This pull request will...
Use `irvingWebpackJsonp` as the `jsonpFunction` name for client builds. This will prevent conflicts with other libraries/packages using the default value.

## Tests: I know this code works because...
Tested locally.