### PR TITLE
Add Coral Comment Count component

### DIFF
--- a/packages/integrations/components/coral/commentCount.js
+++ b/packages/integrations/components/coral/commentCount.js
@@ -9,7 +9,8 @@ const CommentCount = (props) => {
     noText,
   } = props;
 
-  if (! embedUrl) {
+  // We need an embedUrl and articleUrl to proceed.
+  if (! embedUrl || ! articleUrl) {
     return null;
   }
 

--- a/packages/integrations/components/coral/commentCount.js
+++ b/packages/integrations/components/coral/commentCount.js
@@ -1,0 +1,52 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import useLoadScript from '@irvingjs/core/hooks/useLoadScript';
+
+const CommentCount = (props) => {
+  const {
+    articleUrl,
+    embedUrl,
+    noText,
+  } = props;
+
+  if (! embedUrl) {
+    return null;
+  }
+
+  const loaded = useLoadScript(
+    `${embedUrl}/assets/js/count.js`,
+    null,
+    {
+      attr: {
+        className: 'coral-script',
+        defer: true,
+      },
+    }
+  );
+
+  useEffect(() => {
+    if (window.Coral) {
+      console.log('Coral Comment Count');
+    }
+  }, [loaded]);
+
+  return (
+    <span
+      className="coral-count"
+      data-coral-url={articleUrl}
+      data-coral-notext={noText}
+    />
+  );
+};
+
+CommentCount.defaultProps = {
+  noText: false,
+};
+
+CommentCount.propTypes = {
+  articleUrl: PropTypes.string.isRequired,
+  embedUrl: PropTypes.string.isRequired,
+  noText: PropTypes.bool,
+};
+
+export default CommentCount;

--- a/packages/integrations/components/coral/commentCount.js
+++ b/packages/integrations/components/coral/commentCount.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import useLoadScript from '@irvingjs/core/hooks/useLoadScript';
 
@@ -14,7 +14,7 @@ const CommentCount = (props) => {
     return null;
   }
 
-  const loaded = useLoadScript(
+  useLoadScript(
     `${embedUrl}/assets/js/count.js`,
     null,
     {
@@ -24,12 +24,6 @@ const CommentCount = (props) => {
       },
     }
   );
-
-  useEffect(() => {
-    if (window.Coral) {
-      console.log('Coral Comment Count');
-    }
-  }, [loaded]);
 
   return (
     <span


### PR DESCRIPTION
## Issue(s): Relates to or closes...

DEF-111

## Summary: This pull request will...

Adds:
* CommentCount component inside the Coral integrations folder for displaying comment counts of an article from Coral.

## Tests: I know this code works because...

This can be tested along with https://github.com/alleyinteractive/wp-irving/pull/232 or manually, by hard coding a component response in a layout file that passes the following values:

* `articleUrl` – The URL of an article.
* `embedUrl` – The URL to a Coral instance.
* `noText` – Boolean (optional), whether to hide the text and just show the number of comments.