### PR TITLE
Fix bug with cacheClient when redis not configured

### DIFF
--- a/packages/core/server/purgeCache.js
+++ b/packages/core/server/purgeCache.js
@@ -105,7 +105,7 @@ const executeStream = async (pipeline, res, key = '') => {
  * @returns {*}
  */
 const purgeCache = async (req, res) => {
-  if (! cacheService.client) {
+  if (! cacheService.client || ! cacheService.client.pipeline) {
     return res.send('Redis client is not configured.');
   }
 

--- a/packages/vip-go/services/cacheClient.js
+++ b/packages/vip-go/services/cacheClient.js
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
-const defaultService = require(
-  '@irvingjs/core/services/cacheService/defaultService'
-)();
+const defaultClient = require(
+  '@irvingjs/core/services/cacheService/defaultClient'
+);
 
 /**
  * @typedef {object} CacheService
@@ -18,7 +18,7 @@ const getClient = () => {
   });
 
   if (! client) {
-    return defaultService;
+    return defaultClient;
   }
 
   return client;


### PR DESCRIPTION
## Issue(s): Relates to or closes...
[**IRV-639**](https://alleyinteractive.atlassian.net/browse/IRV-639)

## Summary: This pull request will...
* Return core `defaultClient` from vip-go `cacheClient` function instead of `defaultService`
* Add an additional safety check for the `cacheService.client.pipeline` just in case the client is not `null` as it should be when redis isn't configured.

## Tests: I know this code works because...
Tested on client project
