### PR TITLE
fix(byline): remove errant span tag in component with 2 children

### DIFF
--- a/packages/styled-components/components/byline/index.js
+++ b/packages/styled-components/components/byline/index.js
@@ -51,11 +51,9 @@ const Byline = (props) => {
         <BylineWrapper {...standardProps}>
           <AuthorsWrapper data-testid="authors-wrapper">
             {preText && <span>{preText}</span>}
-            <span>
-              <AuthorWrapper>{children[0]}</AuthorWrapper>
-              {singleDelimiter}
-              <AuthorWrapper>{children[1]}</AuthorWrapper>
-            </span>
+            <AuthorWrapper>{children[0]}</AuthorWrapper>
+            {singleDelimiter}
+            <AuthorWrapper>{children[1]}</AuthorWrapper>
           </AuthorsWrapper>
         </BylineWrapper>
       );


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please be sure to review the guide for [contributing to this repo](https://github.com/alleyinteractive/irving/blob/master/CONTRIBUTING.md) and be sure you are following all guidelines.
-->

## Issue(s): Relates to or closes...

N/A

## Summary: This pull request will...

Remove the `<span>` that exists only in the markup for the case of 2 children, which is inconsistent from the markup produced by the other cases (1 child, 3+ children)

## Tests: I know this code works because...

Tested locally
