### PR TITLE
DEF-36: Refactor GTM component so WP hydrates data layer

### DIFF
--- a/packages/integrations/components/googleTagManager/index.js
+++ b/packages/integrations/components/googleTagManager/index.js
@@ -6,7 +6,6 @@ import isNode from '@irvingjs/core/utils/isNode';
 const GoogleTagManager = (props) => {
   const {
     containerId,
-    dataLayer,
   } = props;
 
   if (! containerId) {
@@ -33,18 +32,6 @@ const GoogleTagManager = (props) => {
     }
   }, []);
 
-  /**
-   * Effect for pushing new data to the GTM dataLayer.
-   */
-  useEffect(() => {
-    window.dataLayer.push({
-      event: 'irving.historyChange',
-      ...dataLayer,
-    });
-
-    return () => {};
-  }, [dataLayer]);
-
   return (
     <>
       <Helmet>
@@ -54,8 +41,7 @@ const GoogleTagManager = (props) => {
           {`
             window.dataLayer = window.dataLayer || [];
             if (${isNode()}) {
-              var data = ${JSON.stringify(dataLayer)};
-              data.event = 'irving.initialRender';
+              var data = { event: 'irving.initialRender' };
               window.dataLayer.push(data);
             }
           `}
@@ -79,10 +65,6 @@ const GoogleTagManager = (props) => {
 
 GoogleTagManager.propTypes = {
   containerId: PropTypes.string.isRequired,
-  dataLayer: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.array, // Empty objects turn to arrays in PHP :(
-  ]).isRequired,
 };
 
 export default GoogleTagManager;


### PR DESCRIPTION
Related to https://alleyinteractive.atlassian.net/browse/DEF-36

*Removes `dataLayer` prop from GTM component*
Currently there is no way to filter the data layer for GTM integration. The existing component requires a `dataLayer` prop but the WP Irving integration isn't setup to provide this. I looked around for an example of it being used but I couldn't find one, so I thought it would make the component more maintainable to simply remove the references for now until a time when they may be needed in the future.

*Removes `irving.historyChange` event*
In testing, the `useHook` action of the GTM component would be fired multiple times as the component was rerendered. `useHook` should only render if the second argument changes, so the re-rendering seemed to be occurring because of a parent element. This was an issue regardless of whether the user was logged in or logged out. Going forward, the WP Irving integration will take responsibility for emitting a `irving.page` event every time a new page is loaded.
