### PR TITLE
fix(purgecache): remove duplicative res.end()

### DIFF
--- a/packages/core/server/purgeCache.js
+++ b/packages/core/server/purgeCache.js
@@ -136,8 +136,6 @@ const purgeCache = async (req, res) => {
     res.write(completeMessage);
     return res.end();
   }
-
-  return res.end();
 };
 
 module.exports = purgeCache;


### PR DESCRIPTION
## Issue(s): Relates to or closes...

N/A

## Summary: This pull request will...

* Remove `res.end()` call which was being called too early and therefore resulting in the following error:
```
Error [ERR_STREAM_WRITE_AFTER_END]: write after end
```
(which in practice was causing the Redis cache to not clear)

## Tests: I know this code works because...

Tested locally
