### PR TITLE
Separate component responsible for rendering roots from app wrapper

### DIFF
--- a/packages/core/components/app/index.js
+++ b/packages/core/components/app/index.js
@@ -2,36 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { hot } from 'react-hot-loader/root';
 import { connect } from 'react-redux';
-import RootProviders from 'components/rootProviders';
-import ConnectedRoot from 'components/connectedRoot';
 import ErrorBoundary from 'components/errorBoundary';
-import getRoots from 'selectors/getRoots';
-import getProviders from 'selectors/getProviders';
+import Root from 'components/root';
 import getComponent from 'config/componentMap';
 
 const ErrorMessage = getComponent('error-message');
 const AppContentComponent = getComponent('app');
 
 const App = (props) => {
-  const {
-    error,
-    roots,
-    providers,
-  } = props;
-  const CoreApp = () => (
-    <RootProviders providers={providers}>
-      {roots.map((name) => (
-        <ConnectedRoot key={name} name={name} />
-      ))}
-    </RootProviders>
-  );
+  const { error } = props;
 
   return (
     <ErrorBoundary>
       {error ? (
         <ErrorMessage />
       ) : (
-        <AppContentComponent IrvingApp={CoreApp} />
+        <AppContentComponent IrvingApp={Root} />
       )}
     </ErrorBoundary>
   );
@@ -39,35 +25,26 @@ const App = (props) => {
 
 App.propTypes = {
   /**
-   * Root component configurations
-   */
-  roots: PropTypes.arrayOf(PropTypes.string).isRequired,
-  /**
    * Was there an error loading the page/components?
    */
   error: PropTypes.bool.isRequired,
-  /**
-   * Root provider configurations
-   */
-  providers: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
-const mapStateToProps = (state) => ({
-  roots: getRoots(state),
-  providers: getProviders(state),
+const appMapStateToProps = (state) => ({
   error: !! state.error,
 });
 
-const withRedux = connect(mapStateToProps);
+const ConnectedApp = connect(appMapStateToProps)(App);
+
 let hotApp; // eslint-disable-line import/no-mutable-exports
 
 if (
   'production_client' === process.env.IRVING_EXECUTION_CONTEXT ||
   'development_client' === process.env.IRVING_EXECUTION_CONTEXT
 ) {
-  hotApp = hot(withRedux(App));
+  hotApp = hot(ConnectedApp);
 } else {
-  hotApp = withRedux(App);
+  hotApp = ConnectedApp;
 }
 
 /** @component */

--- a/packages/core/components/root/index.js
+++ b/packages/core/components/root/index.js
@@ -35,7 +35,6 @@ Root.propTypes = {
 const mapStateToProps = (state) => ({
   roots: getRoots(state),
   providers: getProviders(state),
-  error: !! state.error,
 });
 
 export default connect(mapStateToProps)(Root);

--- a/packages/core/components/root/index.js
+++ b/packages/core/components/root/index.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import RootProviders from 'components/rootProviders';
+import ConnectedRoot from 'components/connectedRoot';
+import getRoots from 'selectors/getRoots';
+import getProviders from 'selectors/getProviders';
+
+const Root = (props) => {
+  const {
+    roots,
+    providers,
+  } = props;
+
+  return (
+    <RootProviders providers={providers}>
+      {roots.map((name) => (
+        <ConnectedRoot key={name} name={name} />
+      ))}
+    </RootProviders>
+  );
+};
+
+Root.propTypes = {
+  /**
+   * Root component configurations
+   */
+  roots: PropTypes.arrayOf(PropTypes.string).isRequired,
+  /**
+   * Root provider configurations
+   */
+  providers: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+const mapStateToProps = (state) => ({
+  roots: getRoots(state),
+  providers: getProviders(state),
+  error: !! state.error,
+});
+
+export default connect(mapStateToProps)(Root);

--- a/packages/core/config/html.js
+++ b/packages/core/config/html.js
@@ -1,9 +1,9 @@
 export const richText = {
   allowedTags: [
-    'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol',
     'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'code', 'cite', 'hr', 'br',
     'div', 'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre', 'img',
-    'figure', 'figcaption', 'iframe', 'audio', 'video',
+    'figure', 'figcaption', 'iframe', 'audio', 'video', 'time',
   ],
   allowedAttributes: {
     '*': ['class', 'id', 'data-*', 'style'],


### PR DESCRIPTION
## Summary: This pull request will...
* Split up app component and component responsible for rendering connected roots to prevent unnecessary rerenders.
* Add `h1` and `time` tags to html `allowedTags` because gutenberg supports them.

## Tests: I know this code works because...
Tested in client project.
