### PR TITLE
fix(adminbar): fix React error regarding a change in the order of hooks

### DIFF
--- a/packages/wp-admin-bar/components/adminBar/index.js
+++ b/packages/wp-admin-bar/components/adminBar/index.js
@@ -18,10 +18,6 @@ const AdminBar = (props) => {
   const [hover, setHover] = useState(false);
   const [height, setHeight] = useState(0);
 
-  if (! iframeSrc) {
-    return null;
-  }
-
   useEffect(() => {
     const handleMessage = (event) => {
       if (event.origin !== iframeOrigin) {
@@ -39,6 +35,10 @@ const AdminBar = (props) => {
       window.removeEventListener('message', handleMessage);
     };
   });
+
+  if (! iframeSrc) {
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
## Issue(s): Relates to or closes...

N/A

## Summary: This pull request will...

Fixes the following warning:
```
React has detected a change in the order of Hooks called by AdminBar.
```
This error was happening because the `useEffect` hook was not present for all renders

## Tests: I know this code works because...

Tested locally
