### PR TITLE
fix(integrationsManager): Remove Redux caching of integrations data

### DIFF
--- a/packages/integrations/components/integrationsManager/integrationsManager.test.js
+++ b/packages/integrations/components/integrationsManager/integrationsManager.test.js
@@ -10,55 +10,34 @@ import GoogleAnalytics from '../googleAnalytics';
 const mockStore = configureStore([]);
 
 describe('<IntegrationsManager />', () => {
-  let store;
-
-  it('should render the appropriate integration once hydrated with a configuration', () => {
-    store = mockStore({
-      integrations: {
-        manager: {
-          componentMap: [{
-            key: 'googleAnalytics',
-            props: {
-              trackingId: 'UA-000000-1',
-            },
-          }],
-          hydrated: true,
-        },
-      },
-    });
+  it('should render integrations passed as props', () => {
+    const integrations = {
+      googleAnalytics: {
+        trackingId: 'UA-000000-1',
+      }
+    };
 
     const wrapper = mount(
-      <Provider store={store}>
-        <IntegrationsManager />
-      </Provider>
+      <IntegrationsManager integrations={integrations} />
     );
 
     const result = wrapper.find(GoogleAnalytics);
     const expected = <GoogleAnalytics trackingId="UA-000000-1" />;
+
     // Check to see whether or not the child node has rendered.
     expect(wrapper.contains(expected)).toEqual(true);
     // Ensure the node props match the expected result.
     expect(result.prop('trackingId')).toEqual(mount(expected).prop('trackingId'));
   });
 
-  it('should not render any children if no configuration is present', () => {
-    store = mockStore({
-      integrations: {
-        manager: {
-          componentMap: [],
-          hydrated: false,
-        },
-      },
-    });
+  it('should not render when no integrations are present', () => {
+    const integrations = {};
 
     const wrapper = mount(
-      <Provider store={store}>
-        <IntegrationsManager />
-      </Provider>
+      <IntegrationsManager integrations={integrations} />
     );
 
-    const result = wrapper.find(IntegrationsManager);
-    // The <IntegrationsManager /> node should not contain a specified integration.
-    expect(result.contains(GoogleAnalytics)).toEqual(false);
+    // Check to see whether or not the child node has rendered.
+    expect(wrapper.children().exists()).toEqual(false);
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please be sure to review the guide for [contributing to this repo](https://github.com/alleyinteractive/irving/blob/master/CONTRIBUTING.md) and be sure you are following all guidelines.
-->

## Issue(s): Relates to or closes...

<!-- Does this PR relate to or close any issues? -->

## Summary: This pull request will...

This removes the mechanism that caches integrations data to the Redux store, and instead prefers to
re-render fresh integration data each time the integrations manger is rendered and recieves updates
integration data. This fixes an issue where fresh data being passed from API responses were not
being passed as props to components during page renders.

## Tests: I know this code works because...

After applying this change, you can see that the GTM integration and Pico integration is rendering with fresh data from the components API response.