### PR TITLE
hotfix/fix pico pageinfo updates

### DIFF
--- a/packages/integrations/components/pico/index.js
+++ b/packages/integrations/components/pico/index.js
@@ -79,8 +79,9 @@ const Pico = (props) => {
         ! picoLoaded
       ) {
         mountPicoNodes();
+        // Trigger the visit.
+        window.pico('visit', picoPageInfo);
         // Update the `pico` branch of the state tree and set `loaded` to true.
-        // This will also trigger a visit in the dispatchPicoVisit saga.
         dispatchPicoLoaded();
       }
     }


### PR DESCRIPTION
This reverts a change that is causing the initial container not to load.