### PR TITLE
Update/add pico staging support

### DIFF
--- a/packages/integrations/components/pico/index.js
+++ b/packages/integrations/components/pico/index.js
@@ -129,6 +129,7 @@ const Pico = (props) => {
 
 Pico.defaultProps = {
   tiers: [],
+  widgetUrl: "https://widget.pico.tools",
 };
 
 Pico.propTypes = {
@@ -141,7 +142,7 @@ Pico.propTypes = {
   }).isRequired,
   publisherId: PropTypes.string.isRequired,
   tiers: PropTypes.array,
-  widgetUrl: PropTypes.string.isRequired,
+  widgetUrl: PropTypes.string,
 };
 
 export default Pico;

--- a/packages/integrations/components/pico/index.js
+++ b/packages/integrations/components/pico/index.js
@@ -22,6 +22,7 @@ const Pico = (props) => {
     pageInfo,
     publisherId,
     tiers,
+    widgetUrl,
   } = props;
 
   /**
@@ -107,7 +108,11 @@ const Pico = (props) => {
     return (
       <Helmet>
         <script>
-          {`(function(p,i,c,o){var n=new Event("pico-init");i[p]=i[p]||function(){(i[p].queue=i[p].queue||[]).push(arguments)},i.document.addEventListener("pico-init",function(e){var t=i.Pico.getInstance(e,{publisherId:o,picoInit:n},i);t.handleQueueItems(i[p].queue),i[p]=function(){return t.handleQueueItems([arguments])}},!1);var e=i.document.createElement("script"),t=i.document.getElementsByTagName("script")[0];e.async=1,e.defer=1,e.src=c,e.onload=function(e){return i.Pico.getInstance(e,{publisherId:o,picoInit:n},i)},t.parentNode.insertBefore(e,t)})("pico",window,"https://widget.pico.tools/wrapper.min.js", "${publisherId}");`}
+          {
+            /* eslint-disable max-len */
+            `(function(p,i,c,o){var n=new Event("pico-init");i[p]=i[p]||function(){(i[p].queue=i[p].queue||[]).push(arguments)},i.document.addEventListener("pico-init",function(e){var t=i.Pico.getInstance(e,{publisherId:o,picoInit:n},i);t.handleQueueItems(i[p].queue),i[p]=function(){return t.handleQueueItems([arguments])}},!1);var e=i.document.createElement("script"),t=i.document.getElementsByTagName("script")[0];e.async=1,e.defer=1,e.src=c,e.onload=function(e){return i.Pico.getInstance(e,{publisherId:o,picoInit:n},i)},t.parentNode.insertBefore(e,t)})("pico",window,"${widgetUrl}/wrapper.min.js", "${publisherId}");`
+            /* eslint-enable */
+          }
         </script>
       </Helmet>
     );
@@ -136,6 +141,7 @@ Pico.propTypes = {
   }).isRequired,
   publisherId: PropTypes.string.isRequired,
   tiers: PropTypes.array,
+  widgetUrl: PropTypes.string.isRequired,
 };
 
 export default Pico;


### PR DESCRIPTION
## Issue(s): Relates to or closes...

DEF-323

## Summary: This pull request will...

This uses a `widgetUrl` prop passed from the component API as the basis for loading the widget script
so that we can swap between production and staging.

## Tests: I know this code works because...

You can check the "use staging" option in the WP Irving plugin to pass the staging URL as part of the API response and Irving will load the pico widget code from the staging URL.