### PR TITLE
DISCO-69 Add optional aria-hidden attribute and prop to Link component

### DIFF
--- a/packages/styled-components/components/link/index.js
+++ b/packages/styled-components/components/link/index.js
@@ -41,7 +41,7 @@ const Link = (props) => {
 
   return (
     <LinkWrapper
-      aria-hidden={ariaHidden}
+      aria-hidden={'true' === ariaHidden ? ariaHidden : null}
       data-gtm-action={gtmAction}
       data-gtm-category={gtmCategory}
       data-gtm-label={gtmLabel}
@@ -72,6 +72,7 @@ Link.defaultProps = {
 
 Link.propTypes = {
   ...standardPropTypes,
+  ariaHidden: PropTypes.oneOf([null, 'true']),
   /**
    * Destination for anchor tag (`href` attribute)
    */

--- a/packages/styled-components/components/link/index.js
+++ b/packages/styled-components/components/link/index.js
@@ -18,6 +18,7 @@ import * as defaultStyles from './themes/default';
  */
 const Link = (props) => {
   const {
+    ariaHidden,
     children,
     gtmAction,
     gtmCategory,
@@ -40,6 +41,7 @@ const Link = (props) => {
 
   return (
     <LinkWrapper
+      aria-hidden={ariaHidden}
       data-gtm-action={gtmAction}
       data-gtm-category={gtmCategory}
       data-gtm-label={gtmLabel}
@@ -57,6 +59,7 @@ const Link = (props) => {
 
 Link.defaultProps = {
   ...standardDefaultProps,
+  ariaHidden: null,
   theme: defaultStyles,
   onClick: false,
   rel: '',


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please be sure to review the guide for [contributing to this repo](https://github.com/alleyinteractive/irving/blob/master/CONTRIBUTING.md) and be sure you are following all guidelines.
-->

## Issue(s): Relates to or closes...

https://alleyinteractive.atlassian.net/browse/DISCO-69

## Summary: This pull request will...

Add an optional `aria-hidden` attribute to the Link component, which takes its value from an optional `ariaHidden` prop. The default value of the `ariaHidden` prop is `null`, so that if no `ariaHidden` prop is passed to the Link component, the `aria-hidden` attribute will not appear on the rendered `<a>` element.

The motivation behind this was to provide a way to hide links that do not contain descriptive text, and should not be read by a screen reader. In this specific case, during work on an accessibility audit for site that's using Irving, an issue with the Byline component came up: the author avatar and author name are separate links, and the avatar link contains only an image. 

Accessibility requirements dictate that links should contain descriptive text or that the linked image should contain `alt` text, to give screen reader users some information about the linked content. In this case it did not make sense to add descriptive text, as that would result in duplicate link descriptions. Nor did it make sense to add `alt` text to the image, as it is purely decorative, and it would again result in duplicate link descriptions.

We might consider changes to the Byline component in the future to address this duplicate link issue, but for now this was the best solution to the specific a11y issue, and it's also a valuable addition to the Link component in general.

## Tests: I know this code works because...
I've tested it locally on a project that uses Irving. The `aria-hidden` attribute only appears on the rendered `<a>` element when the `ariaHidden` prop is passed to the component with a value of `true`.

