### PR TITLE
fix(pico): Trigger Pico actions on pre-fetched pages

### DIFF
--- a/packages/integrations/components/pico/index.js
+++ b/packages/integrations/components/pico/index.js
@@ -43,15 +43,9 @@ const Pico = (props) => {
   const [picoInitialized, setPicoInitialized] = useState(false);
   // Create the dispatch function.
   const dispatch = useDispatch();
-  // Create a state value that prevents multiple `UPDATE_PICO_PAGE_INFO` actions
-  // from being fired on a single `LOCATION_CHANGE`.
-  const [picoPageInfoUpdated, setPicoPageInfoUpdated] = useState(false);
   // Create a function that dispatches the current page info for the saga to respond to.
   const dispatchUpdatePicoPageInfo = useCallback(
-    (payload) => {
-      setPicoPageInfoUpdated(true);
-      return dispatch(actionUpdatePicoPageInfo(payload));
-    },
+    (payload) => dispatch(actionUpdatePicoPageInfo(payload)),
     [dispatch]
   );
   // Create a function that updates the store when the `pico.loaded` event is fired.
@@ -64,6 +58,25 @@ const Pico = (props) => {
 
   // Retrieve the Coral SSO token from the Redux store.
   const coralToken = useSelector(tokenSelector);
+
+  useEffect(() => {
+    const initHandler = () => {
+      setPicoInitialized(true);
+    };
+
+    // On component hydration, add an event listener to watch for the script's init event.
+    window.document.addEventListener('pico-init', initHandler);
+
+    return () => window.document.removeEventListener('pico-init', initHandler);
+  }, []);
+
+  useEffect(() => {
+    // Only update the store once Pico has loaded and if it has not already been
+    // updated in this component's lifecycle phase.
+    if (picoLoaded) {
+      dispatchUpdatePicoPageInfo(picoPageInfo);
+    }
+  }, [picoLoaded, picoPageInfo.url]);
 
   useEffect(() => {
     // See if the Pico widget container exists in the DOM.
@@ -80,28 +93,11 @@ const Pico = (props) => {
         ! picoLoaded
       ) {
         mountPicoNodes();
-        // Trigger the visit.
-        window.pico('visit', picoPageInfo);
         // Update the `pico` branch of the state tree and set `loaded` to true.
         dispatchPicoLoaded();
       }
     }
-
-    // Only update the store once Pico has loaded and if it has not already been
-    // updated in this component's lifecycle phase.
-    if (picoLoaded && ! picoPageInfoUpdated) {
-      dispatchUpdatePicoPageInfo(picoPageInfo);
-    }
-
-    const initHandler = () => {
-      setPicoInitialized(true);
-    };
-
-    // On component hydration, add an event listener to watch for the script's init event.
-    window.document.addEventListener('pico-init', initHandler);
-
-    return () => window.document.removeEventListener('pico-init', initHandler);
-  }, [picoInitialized, picoLoaded, picoPageInfoUpdated]);
+  }, [picoLoaded]);
 
   // Load the script for the first time.
   if (! picoInitialized) {

--- a/packages/integrations/sagas/picoSaga.js
+++ b/packages/integrations/sagas/picoSaga.js
@@ -50,10 +50,7 @@ function* dispatchPicoVisit() {
   const picoLoaded = yield select(picoLoadedSelector);
   const picoPageInfo = yield select(picoPageInfoSelector);
 
-  if (
-    (picoLoaded && picoPageInfo) &&
-    'function' === typeof window.Pico.handleNavigationEvent
-  ) {
+  if (picoLoaded && picoPageInfo) {
     window.pico('visit', picoPageInfo);
   }
 }


### PR DESCRIPTION
## Issue(s): Relates to or closes...

IRV-710

## Summary: This pull request will...

This fixes a bug where pre-fetched pages were not triggering Pico actions
because the Pico component was being rendered from the previous page's
state. We had previously included a check for whether we had already
dispatched a Pico page update using a `useState` hook to bypass duplicate
dispatches and that state was not being reset between pageviews if the Pico
component instance was being reused.

This refactors the logic for side effects into several separate `useEffect`
hooks to separate responsibilities for each side effect and simplify the
number of dependencies each `useEffect` checks before running.

## Tests: I know this code works because...

<!-- How will you or do you know your code works? Example: The tests you wrote, the commands you ran and their output, screenshots / videos if the pull request changes components or something user-facing. -->
