### PR TITLE
fix(Pico): ensure Pico loads on first page render

### DIFF
--- a/packages/integrations/components/pico/index.js
+++ b/packages/integrations/components/pico/index.js
@@ -15,7 +15,10 @@ import {
 } from '../../actions/coralActions';
 import { tokenSelector } from '../../selectors/coralSelector';
 // Utility functions.
-import mountPicoNodes from './utils';
+import {
+  isPicoMounted,
+  mountPicoNodes,
+} from './utils';
 
 const Pico = (props) => {
   const {
@@ -83,21 +86,16 @@ const Pico = (props) => {
     const widgetContainer = document.getElementById('pico-widget-container');
 
     if (widgetContainer) {
-      // Prevent the widget script from being added more than once.
-      setPicoInitialized(true);
-
       // Ensure the target nodes are only mounted once on the initial server load.
-      if (
-        ! document.getElementById('PicoSignal-container') &&
-        ! document.getElementById('PicoRule-button') &&
-        ! picoLoaded
-      ) {
+      if (! isPicoMounted()) {
         mountPicoNodes();
+        // Dispatch initial Pico page visit.
+        dispatchUpdatePicoPageInfo(picoPageInfo);
         // Update the `pico` branch of the state tree and set `loaded` to true.
         dispatchPicoLoaded();
       }
     }
-  }, [picoLoaded]);
+  }, []);
 
   // Load the script for the first time.
   if (! picoInitialized) {

--- a/packages/integrations/components/pico/utils.js
+++ b/packages/integrations/components/pico/utils.js
@@ -47,13 +47,25 @@ function mountSignupFormNodes(documentBody) {
 }
 
 /**
+ * Helper function to see if Pico has already been mounted.
+ *
+ * @return {bool} Whether the Pico nodes are mounted in the DOM.
+ */
+export function isPicoMounted() {
+  return (
+    document.getElementById('PicoSignal-container') &&
+    document.getElementById('PicoRule-button')
+  );
+}
+
+/**
  * A function that mounts reference nodes into the DOM at initialization. These
  * nodes can be targeted by React components to trigger Pico actions if the component
  * requesting an action is rendered after Pico's initialization.
  *
  * @param {object} pageInfo The curren page info.
  */
-export default function mountPicoNodes() {
+export function mountPicoNodes() {
   // Get the `body` DOM node.
   const documentBody = document.getElementsByTagName('body')[0];
 


### PR DESCRIPTION
This fixes a bug introduced in b590767 that caused Pico not to fire the initial page visit for the
initial pageview.

See: IRV-710