### PR TITLE
fix(pico): Fix timing bug with firing the initial Pico action

### DIFF
--- a/packages/integrations/components/pico/index.js
+++ b/packages/integrations/components/pico/index.js
@@ -92,10 +92,10 @@ const Pico = (props) => {
       // Ensure the target nodes are only mounted once on the initial server load.
       if (! isPicoMounted() && ! picoLoaded) {
         mountPicoNodes();
-        // Dispatch initial Pico page visit.
-        dispatchUpdatePicoPageInfo(picoPageInfo);
         // Update the `pico` branch of the state tree and set `loaded` to true.
         dispatchPicoLoaded();
+        // Dispatch initial Pico page visit.
+        dispatchUpdatePicoPageInfo(picoPageInfo);
       }
     }
   }, [picoLoaded]);


### PR DESCRIPTION
This changes the order of the initial dispatched actions after the Pico notes are mounted in ordre
to try and fix a race condition where the first payload to Pico is being fired too early.

IRV-710
