### PR TITLE
IRV-710: Fix Pico load states

### DIFF
--- a/packages/integrations/components/pico/index.js
+++ b/packages/integrations/components/pico/index.js
@@ -98,7 +98,7 @@ const Pico = (props) => {
         dispatchUpdatePicoPageInfo(picoPageInfo);
       }
     }
-  }, [picoLoaded]);
+  }, [picoLoaded, picoPageInfo.url]);
 
   // Load the script for the first time.
   if (! picoInitialized) {

--- a/packages/integrations/components/pico/index.js
+++ b/packages/integrations/components/pico/index.js
@@ -94,8 +94,6 @@ const Pico = (props) => {
         mountPicoNodes();
         // Update the `pico` branch of the state tree and set `loaded` to true.
         dispatchPicoLoaded();
-        // Dispatch initial Pico page visit.
-        dispatchUpdatePicoPageInfo(picoPageInfo);
       }
     }
   }, [picoLoaded, picoPageInfo.url]);


### PR DESCRIPTION
This PR fixes an issue where the Pico `pageInfo` would not be updated when navigating through article pages and viewing the same article more than once. This is done by removing an extraneous call to `dispatchPicoPageInfo` that was causing the action to be fired twice on an initial server render and adding the current URL as a dependency to the mount effect hook.