### PR TITLE
Fix issue with spreading props into link wrapper component

### DIFF
--- a/packages/styled-components/components/link/index.js
+++ b/packages/styled-components/components/link/index.js
@@ -18,7 +18,6 @@ import * as defaultStyles from './themes/default';
  */
 const Link = (props) => {
   const {
-    ariaHidden,
     children,
     gtmAction,
     gtmCategory,
@@ -38,12 +37,21 @@ const Link = (props) => {
     LinkWrapper,
   } = theme;
   const standardProps = useStandardProps(props);
+  const ariaProps = Object.keys(props).reduce((acc, propName) => {
+    if (! propName.includes('aria')) {
+      return acc;
+    }
+
+    return {
+      ...acc,
+      [propName]: props[propName],
+    };
+  });
 
   return (
     <LinkWrapper
-      {...props}
       {...standardProps}
-      aria-hidden={'true' === ariaHidden ? ariaHidden : null}
+      {...ariaProps}
       data-gtm-action={gtmAction}
       data-gtm-category={gtmCategory}
       data-gtm-label={gtmLabel}


### PR DESCRIPTION
## Summary: This pull request will...
Spreading `{...props}` into the link wrapper caused the `theme` prop in the `LinkWrapper` styled component to be overridden, causing `siteTheme` to break. This PR will fix this issue.

## Tests: I know this code works because...
Tested in client projects.
