### PR TITLE
fix(coral): Enforce component re-renders on selector variable changes

### DIFF
--- a/packages/integrations/components/pico/index.js
+++ b/packages/integrations/components/pico/index.js
@@ -20,7 +20,7 @@ import {
   mountPicoNodes,
 } from './utils';
 
-const log = getLogService('irving:pico');
+const log = getLogService('irving:integrations:pico');
 
 const Pico = (props) => {
   const {

--- a/packages/integrations/package-lock.json
+++ b/packages/integrations/package-lock.json
@@ -14,15 +14,10 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.11.0.tgz",
-			"integrity": "sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==",
-			"dev": true,
-			"requires": {
-				"browserslist": "^4.12.0",
-				"invariant": "^2.2.4",
-				"semver": "^5.5.0"
-			}
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.0.tgz",
+			"integrity": "sha512-jAbCtMANC9ptXxbSVXIqV/3H0bkh7iyyv6JS5lu10av45bcc2QmDNJXkASZCFwbBt75Q0AEq/BB+bNa3x1QgYQ==",
+			"dev": true
 		},
 		"@babel/core": {
 			"version": "7.10.3",
@@ -76,9 +71,9 @@
 					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -111,9 +106,9 @@
 					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -146,9 +141,9 @@
 					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -165,14 +160,14 @@
 			}
 		},
 		"@babel/helper-builder-react-jsx-experimental": {
-			"version": "7.11.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.11.5.tgz",
-			"integrity": "sha512-Vc4aPJnRZKWfzeCBsqTBnzulVNjABVdahSPhtdMD3Vs80ykx4a87jTHtF/VR+alSrDmNvat7l13yrRHauGcHVw==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.0.tgz",
+			"integrity": "sha512-AFzu6ib4i56olCtulkbIifcTay0O5tv8ZVK8hZMzrpu+YjsIDEcesF1DMqqTzV65clu3X61aE7qeHcJsY/gmnA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.10.4",
 				"@babel/helper-module-imports": "^7.10.4",
-				"@babel/types": "^7.11.5"
+				"@babel/types": "^7.12.0"
 			},
 			"dependencies": {
 				"@babel/helper-module-imports": {
@@ -191,9 +186,9 @@
 					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -210,29 +205,28 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
-			"integrity": "sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.0.tgz",
+			"integrity": "sha512-NbDFJNjDgxE7IkrHp5gq2+Tr8bEdCLKYN90YDQEjMiTMUAFAcShNkaH8kydcmU0mEQTiQY0Ydy/+1xfS2OCEnw==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.10.4",
+				"@babel/compat-data": "^7.12.0",
+				"@babel/helper-validator-option": "^7.12.0",
 				"browserslist": "^4.12.0",
-				"invariant": "^2.2.4",
-				"levenary": "^1.1.1",
 				"semver": "^5.5.0"
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
-			"integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.0.tgz",
+			"integrity": "sha512-9tD1r9RK928vxvxcoNK8/7uwT7Q2DJZP1dnJmyMAJPwOF0yr8PPwqdpyw33lUpCfrJ765bOs5XNa4KSfUDWFSw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-member-expression-to-functions": "^7.10.5",
+				"@babel/helper-member-expression-to-functions": "^7.12.0",
 				"@babel/helper-optimise-call-expression": "^7.10.4",
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.0",
 				"@babel/helper-split-export-declaration": "^7.10.4"
 			},
 			"dependencies": {
@@ -246,12 +240,12 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.11.6",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-					"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.0.tgz",
+					"integrity": "sha512-8lnf4QcyiQMf5XQp47BltuMTocsOh6P0z/vueEh8GzhmWWlDbdvOoI5Ziddg0XYhmnx35HyByUW51/9NprF8cA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.5",
+						"@babel/types": "^7.12.0",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
@@ -277,12 +271,12 @@
 					}
 				},
 				"@babel/helper-member-expression-to-functions": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.0.tgz",
+					"integrity": "sha512-I0d/bgzgzgLsJMk7UZ0TN2KV3OGjC/t/9Saz8PKb9jrcEAXhgjGysOgp4PDKydIKjUv/gj2St4ae+ov8l+T9Xg==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.0"
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-optimise-call-expression": {
@@ -301,15 +295,15 @@
 					"dev": true
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.0.tgz",
+					"integrity": "sha512-9kycFdq2c9e7PXZOr2z/ZqTFF9OzFu287iFwYS+CiDVPuoTCfY8hoTsIqNQNetQjlqoRsRyJFrMG1uhGAR4EEw==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.10.4",
+						"@babel/helper-member-expression-to-functions": "^7.12.0",
 						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
@@ -339,9 +333,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+					"integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -356,26 +350,26 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-					"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.0.tgz",
+					"integrity": "sha512-ZU9e79xpOukCNPkQ1UzR4gJKCruGckr6edd8v8lmKpSk8iakgUIvb+5ZtaKKV9f7O+x5r+xbMDDIbzVpUoiIuw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.11.5",
+						"@babel/generator": "^7.12.0",
 						"@babel/helper-function-name": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.11.5",
-						"@babel/types": "^7.11.5",
+						"@babel/parser": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -392,14 +386,14 @@
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
-			"integrity": "sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.0.tgz",
+			"integrity": "sha512-YBqH+3wLcom+tko8/JLgRcG8DMqORgmjqNRNI751gTioJSZHWFybO1mRoLtJtWIlYSHY+zT9LqqnbbK1c3KIVQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.10.4",
 				"@babel/helper-regex": "^7.10.4",
-				"regexpu-core": "^4.7.0"
+				"regexpu-core": "^4.7.1"
 			}
 		},
 		"@babel/helper-define-map": {
@@ -460,9 +454,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+					"integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -477,9 +471,9 @@
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -511,9 +505,9 @@
 					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -565,9 +559,9 @@
 					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -687,9 +681,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+					"integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -704,9 +698,9 @@
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -760,9 +754,9 @@
 					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -793,6 +787,12 @@
 			"integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
 			"dev": true
 		},
+		"@babel/helper-validator-option": {
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.0.tgz",
+			"integrity": "sha512-NRfKaAQw/JCMsTFUdJI6cp4MoJGGVBRQTRSiW1nwlGldNqzjB9jqWI0SZqQksC724dJoKqwG+QqfS9ib7SoVsw==",
+			"dev": true
+		},
 		"@babel/helper-wrap-function": {
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
@@ -815,12 +815,12 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.11.6",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-					"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.0.tgz",
+					"integrity": "sha512-8lnf4QcyiQMf5XQp47BltuMTocsOh6P0z/vueEh8GzhmWWlDbdvOoI5Ziddg0XYhmnx35HyByUW51/9NprF8cA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.5",
+						"@babel/types": "^7.12.0",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
@@ -872,9 +872,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+					"integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -889,26 +889,26 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-					"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.0.tgz",
+					"integrity": "sha512-ZU9e79xpOukCNPkQ1UzR4gJKCruGckr6edd8v8lmKpSk8iakgUIvb+5ZtaKKV9f7O+x5r+xbMDDIbzVpUoiIuw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.11.5",
+						"@babel/generator": "^7.12.0",
 						"@babel/helper-function-name": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.11.5",
-						"@babel/types": "^7.11.5",
+						"@babel/parser": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -1008,9 +1008,9 @@
 			}
 		},
 		"@babel/plugin-proposal-export-namespace-from": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.10.4.tgz",
-			"integrity": "sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.0.tgz",
+			"integrity": "sha512-ao43U2ptSe+mIZAQo2nBV5Wx2Ie3i2XbLt8jCXZpv+bvLY1Twv0lak4YZ1Ps5OwbeLMAl3iOVScgGMOImBae1g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -1044,9 +1044,9 @@
 			}
 		},
 		"@babel/plugin-proposal-logical-assignment-operators": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.11.0.tgz",
-			"integrity": "sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.0.tgz",
+			"integrity": "sha512-dssjXHzdMQal4q6GCSwDTVPEbyBLdd9+7aSlzAkQbrGEKq5xG8pvhQ7u2ktUrCLRmzQphZnSzILBL5ta4xSRlA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -1071,9 +1071,9 @@
 			}
 		},
 		"@babel/plugin-proposal-nullish-coalescing-operator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
-			"integrity": "sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.0.tgz",
+			"integrity": "sha512-JpNWix2VP2ue31r72fKytTE13nPX1fxl1mudfTaTwcDhl3iExz5NZjQBq012b/BQ6URWoc/onI73pZdYlAfihg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -1089,9 +1089,9 @@
 			}
 		},
 		"@babel/plugin-proposal-numeric-separator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
-			"integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.0.tgz",
+			"integrity": "sha512-iON65YmIy/IpEgteYJ4HfO2q30SLdIxiyjNNlsSjSl0tUxLhSH9PljE5r6sczwdW64ZZzznYNcezdcROB+rDDw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -1153,9 +1153,9 @@
 			}
 		},
 		"@babel/plugin-proposal-optional-chaining": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz",
-			"integrity": "sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.0.tgz",
+			"integrity": "sha512-CXu9aw32FH/MksqdKvhpiH8pSvxnXJ33E7I7BGNE9VzNRpWgpNzvPpds/tW9E0pjmX9+D1zAHRyHbtyeTboo2g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -1408,9 +1408,9 @@
 					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -1486,12 +1486,12 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.11.6",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-					"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.0.tgz",
+					"integrity": "sha512-8lnf4QcyiQMf5XQp47BltuMTocsOh6P0z/vueEh8GzhmWWlDbdvOoI5Ziddg0XYhmnx35HyByUW51/9NprF8cA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.5",
+						"@babel/types": "^7.12.0",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
@@ -1517,12 +1517,12 @@
 					}
 				},
 				"@babel/helper-member-expression-to-functions": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.0.tgz",
+					"integrity": "sha512-I0d/bgzgzgLsJMk7UZ0TN2KV3OGjC/t/9Saz8PKb9jrcEAXhgjGysOgp4PDKydIKjUv/gj2St4ae+ov8l+T9Xg==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.0"
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-optimise-call-expression": {
@@ -1541,15 +1541,15 @@
 					"dev": true
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.0.tgz",
+					"integrity": "sha512-9kycFdq2c9e7PXZOr2z/ZqTFF9OzFu287iFwYS+CiDVPuoTCfY8hoTsIqNQNetQjlqoRsRyJFrMG1uhGAR4EEw==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.10.4",
+						"@babel/helper-member-expression-to-functions": "^7.12.0",
 						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
@@ -1579,9 +1579,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+					"integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -1596,26 +1596,26 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-					"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.0.tgz",
+					"integrity": "sha512-ZU9e79xpOukCNPkQ1UzR4gJKCruGckr6edd8v8lmKpSk8iakgUIvb+5ZtaKKV9f7O+x5r+xbMDDIbzVpUoiIuw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.11.5",
+						"@babel/generator": "^7.12.0",
 						"@babel/helper-function-name": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.11.5",
-						"@babel/types": "^7.11.5",
+						"@babel/parser": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -1798,9 +1798,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+					"integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -1815,9 +1815,9 @@
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -1888,12 +1888,12 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.11.6",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-					"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.0.tgz",
+					"integrity": "sha512-8lnf4QcyiQMf5XQp47BltuMTocsOh6P0z/vueEh8GzhmWWlDbdvOoI5Ziddg0XYhmnx35HyByUW51/9NprF8cA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.5",
+						"@babel/types": "^7.12.0",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
@@ -1919,12 +1919,12 @@
 					}
 				},
 				"@babel/helper-member-expression-to-functions": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.0.tgz",
+					"integrity": "sha512-I0d/bgzgzgLsJMk7UZ0TN2KV3OGjC/t/9Saz8PKb9jrcEAXhgjGysOgp4PDKydIKjUv/gj2St4ae+ov8l+T9Xg==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.0"
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-module-imports": {
@@ -1937,17 +1937,19 @@
 					}
 				},
 				"@babel/helper-module-transforms": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-					"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.0.tgz",
+					"integrity": "sha512-1ZTMoCiLSzTJLbq7mSaTHki4oIrBIf/dUbzdhwTrvtMU3ZNVKwQmGae3gSiqppo7G8HAgnXmc43rfEaD8yYLLQ==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-imports": "^7.10.4",
-						"@babel/helper-replace-supers": "^7.10.4",
+						"@babel/helper-replace-supers": "^7.12.0",
 						"@babel/helper-simple-access": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.11.0",
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"lodash": "^4.17.19"
 					}
 				},
@@ -1967,15 +1969,15 @@
 					"dev": true
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.0.tgz",
+					"integrity": "sha512-9kycFdq2c9e7PXZOr2z/ZqTFF9OzFu287iFwYS+CiDVPuoTCfY8hoTsIqNQNetQjlqoRsRyJFrMG1uhGAR4EEw==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.10.4",
+						"@babel/helper-member-expression-to-functions": "^7.12.0",
 						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-simple-access": {
@@ -2015,9 +2017,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+					"integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -2032,26 +2034,26 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-					"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.0.tgz",
+					"integrity": "sha512-ZU9e79xpOukCNPkQ1UzR4gJKCruGckr6edd8v8lmKpSk8iakgUIvb+5ZtaKKV9f7O+x5r+xbMDDIbzVpUoiIuw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.11.5",
+						"@babel/generator": "^7.12.0",
 						"@babel/helper-function-name": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.11.5",
-						"@babel/types": "^7.11.5",
+						"@babel/parser": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -2089,12 +2091,12 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.11.6",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-					"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.0.tgz",
+					"integrity": "sha512-8lnf4QcyiQMf5XQp47BltuMTocsOh6P0z/vueEh8GzhmWWlDbdvOoI5Ziddg0XYhmnx35HyByUW51/9NprF8cA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.5",
+						"@babel/types": "^7.12.0",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
@@ -2120,12 +2122,12 @@
 					}
 				},
 				"@babel/helper-member-expression-to-functions": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.0.tgz",
+					"integrity": "sha512-I0d/bgzgzgLsJMk7UZ0TN2KV3OGjC/t/9Saz8PKb9jrcEAXhgjGysOgp4PDKydIKjUv/gj2St4ae+ov8l+T9Xg==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.0"
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-module-imports": {
@@ -2138,17 +2140,19 @@
 					}
 				},
 				"@babel/helper-module-transforms": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-					"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.0.tgz",
+					"integrity": "sha512-1ZTMoCiLSzTJLbq7mSaTHki4oIrBIf/dUbzdhwTrvtMU3ZNVKwQmGae3gSiqppo7G8HAgnXmc43rfEaD8yYLLQ==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-imports": "^7.10.4",
-						"@babel/helper-replace-supers": "^7.10.4",
+						"@babel/helper-replace-supers": "^7.12.0",
 						"@babel/helper-simple-access": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.11.0",
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"lodash": "^4.17.19"
 					}
 				},
@@ -2168,15 +2172,15 @@
 					"dev": true
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.0.tgz",
+					"integrity": "sha512-9kycFdq2c9e7PXZOr2z/ZqTFF9OzFu287iFwYS+CiDVPuoTCfY8hoTsIqNQNetQjlqoRsRyJFrMG1uhGAR4EEw==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.10.4",
+						"@babel/helper-member-expression-to-functions": "^7.12.0",
 						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-simple-access": {
@@ -2216,9 +2220,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+					"integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -2233,26 +2237,26 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-					"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.0.tgz",
+					"integrity": "sha512-ZU9e79xpOukCNPkQ1UzR4gJKCruGckr6edd8v8lmKpSk8iakgUIvb+5ZtaKKV9f7O+x5r+xbMDDIbzVpUoiIuw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.11.5",
+						"@babel/generator": "^7.12.0",
 						"@babel/helper-function-name": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.11.5",
-						"@babel/types": "^7.11.5",
+						"@babel/parser": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -2269,14 +2273,15 @@
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
-			"integrity": "sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.0.tgz",
+			"integrity": "sha512-h2fDMnwRwBiNMmTGAWqUo404Z3oLbrPE6hyATecyIbsEsrbM5gjLbfKQLb6hjiouMlGHH+yliYBbc4NPgWKE/g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.10.4",
-				"@babel/helper-module-transforms": "^7.10.5",
+				"@babel/helper-module-transforms": "^7.12.0",
 				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-identifier": "^7.10.4",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			},
 			"dependencies": {
@@ -2290,12 +2295,12 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.11.6",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-					"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.0.tgz",
+					"integrity": "sha512-8lnf4QcyiQMf5XQp47BltuMTocsOh6P0z/vueEh8GzhmWWlDbdvOoI5Ziddg0XYhmnx35HyByUW51/9NprF8cA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.5",
+						"@babel/types": "^7.12.0",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
@@ -2321,12 +2326,12 @@
 					}
 				},
 				"@babel/helper-member-expression-to-functions": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.0.tgz",
+					"integrity": "sha512-I0d/bgzgzgLsJMk7UZ0TN2KV3OGjC/t/9Saz8PKb9jrcEAXhgjGysOgp4PDKydIKjUv/gj2St4ae+ov8l+T9Xg==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.0"
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-module-imports": {
@@ -2339,17 +2344,19 @@
 					}
 				},
 				"@babel/helper-module-transforms": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-					"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.0.tgz",
+					"integrity": "sha512-1ZTMoCiLSzTJLbq7mSaTHki4oIrBIf/dUbzdhwTrvtMU3ZNVKwQmGae3gSiqppo7G8HAgnXmc43rfEaD8yYLLQ==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-imports": "^7.10.4",
-						"@babel/helper-replace-supers": "^7.10.4",
+						"@babel/helper-replace-supers": "^7.12.0",
 						"@babel/helper-simple-access": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.11.0",
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"lodash": "^4.17.19"
 					}
 				},
@@ -2369,15 +2376,15 @@
 					"dev": true
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.0.tgz",
+					"integrity": "sha512-9kycFdq2c9e7PXZOr2z/ZqTFF9OzFu287iFwYS+CiDVPuoTCfY8hoTsIqNQNetQjlqoRsRyJFrMG1uhGAR4EEw==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.10.4",
+						"@babel/helper-member-expression-to-functions": "^7.12.0",
 						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-simple-access": {
@@ -2417,9 +2424,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+					"integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -2434,26 +2441,26 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-					"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.0.tgz",
+					"integrity": "sha512-ZU9e79xpOukCNPkQ1UzR4gJKCruGckr6edd8v8lmKpSk8iakgUIvb+5ZtaKKV9f7O+x5r+xbMDDIbzVpUoiIuw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.11.5",
+						"@babel/generator": "^7.12.0",
 						"@babel/helper-function-name": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.11.5",
-						"@babel/types": "^7.11.5",
+						"@babel/parser": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -2489,12 +2496,12 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.11.6",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-					"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.0.tgz",
+					"integrity": "sha512-8lnf4QcyiQMf5XQp47BltuMTocsOh6P0z/vueEh8GzhmWWlDbdvOoI5Ziddg0XYhmnx35HyByUW51/9NprF8cA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.5",
+						"@babel/types": "^7.12.0",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
@@ -2520,12 +2527,12 @@
 					}
 				},
 				"@babel/helper-member-expression-to-functions": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.0.tgz",
+					"integrity": "sha512-I0d/bgzgzgLsJMk7UZ0TN2KV3OGjC/t/9Saz8PKb9jrcEAXhgjGysOgp4PDKydIKjUv/gj2St4ae+ov8l+T9Xg==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.0"
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-module-imports": {
@@ -2538,17 +2545,19 @@
 					}
 				},
 				"@babel/helper-module-transforms": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-					"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.0.tgz",
+					"integrity": "sha512-1ZTMoCiLSzTJLbq7mSaTHki4oIrBIf/dUbzdhwTrvtMU3ZNVKwQmGae3gSiqppo7G8HAgnXmc43rfEaD8yYLLQ==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-imports": "^7.10.4",
-						"@babel/helper-replace-supers": "^7.10.4",
+						"@babel/helper-replace-supers": "^7.12.0",
 						"@babel/helper-simple-access": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.11.0",
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"lodash": "^4.17.19"
 					}
 				},
@@ -2568,15 +2577,15 @@
 					"dev": true
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.0.tgz",
+					"integrity": "sha512-9kycFdq2c9e7PXZOr2z/ZqTFF9OzFu287iFwYS+CiDVPuoTCfY8hoTsIqNQNetQjlqoRsRyJFrMG1uhGAR4EEw==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.10.4",
+						"@babel/helper-member-expression-to-functions": "^7.12.0",
 						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-simple-access": {
@@ -2616,9 +2625,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+					"integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -2633,26 +2642,26 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-					"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.0.tgz",
+					"integrity": "sha512-ZU9e79xpOukCNPkQ1UzR4gJKCruGckr6edd8v8lmKpSk8iakgUIvb+5ZtaKKV9f7O+x5r+xbMDDIbzVpUoiIuw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.11.5",
+						"@babel/generator": "^7.12.0",
 						"@babel/helper-function-name": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.11.5",
-						"@babel/types": "^7.11.5",
+						"@babel/parser": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -2714,12 +2723,12 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.11.6",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-					"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.0.tgz",
+					"integrity": "sha512-8lnf4QcyiQMf5XQp47BltuMTocsOh6P0z/vueEh8GzhmWWlDbdvOoI5Ziddg0XYhmnx35HyByUW51/9NprF8cA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.5",
+						"@babel/types": "^7.12.0",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
@@ -2745,12 +2754,12 @@
 					}
 				},
 				"@babel/helper-member-expression-to-functions": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.0.tgz",
+					"integrity": "sha512-I0d/bgzgzgLsJMk7UZ0TN2KV3OGjC/t/9Saz8PKb9jrcEAXhgjGysOgp4PDKydIKjUv/gj2St4ae+ov8l+T9Xg==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.0"
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-optimise-call-expression": {
@@ -2769,15 +2778,15 @@
 					"dev": true
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.0.tgz",
+					"integrity": "sha512-9kycFdq2c9e7PXZOr2z/ZqTFF9OzFu287iFwYS+CiDVPuoTCfY8hoTsIqNQNetQjlqoRsRyJFrMG1uhGAR4EEw==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.10.4",
+						"@babel/helper-member-expression-to-functions": "^7.12.0",
 						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
@@ -2807,9 +2816,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+					"integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -2824,26 +2833,26 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-					"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.0.tgz",
+					"integrity": "sha512-ZU9e79xpOukCNPkQ1UzR4gJKCruGckr6edd8v8lmKpSk8iakgUIvb+5ZtaKKV9f7O+x5r+xbMDDIbzVpUoiIuw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.11.5",
+						"@babel/generator": "^7.12.0",
 						"@babel/helper-function-name": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.11.5",
-						"@babel/types": "^7.11.5",
+						"@babel/parser": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -2891,9 +2900,9 @@
 					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -3080,9 +3089,9 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.11.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.5.tgz",
-			"integrity": "sha512-9aIoee+EhjySZ6vY5hnLjigHzunBlscx9ANKutkeWTJTx6m5Rbq6Ic01tLvO54lSusR+BxV7u4UDdCmXv5aagg==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.0.tgz",
+			"integrity": "sha512-BC8wiTo+0kEG8M6wuEBeuG7AIazTan02/Bh4dgi+wdDBE+p2iv5AXO8OUjrwD100223S/2WbALSqj7c290XTKg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.10.4",
@@ -3113,9 +3122,9 @@
 					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -3255,26 +3264,27 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.11.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.5.tgz",
-			"integrity": "sha512-kXqmW1jVcnB2cdueV+fyBM8estd5mlNfaQi6lwLgRwCby4edpavgbFhiBNjmWA3JpB/yZGSISa7Srf+TwxDQoA==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.0.tgz",
+			"integrity": "sha512-jSIHvHSuF+hBUIrvA2/61yIzhH+ceLOXGLTH1nwPvQlso/lNxXsoE/nvrCzY5M77KRzhKegB1CvdhWPZmYDZ5A==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.11.0",
-				"@babel/helper-compilation-targets": "^7.10.4",
+				"@babel/compat-data": "^7.12.0",
+				"@babel/helper-compilation-targets": "^7.12.0",
 				"@babel/helper-module-imports": "^7.10.4",
 				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-option": "^7.12.0",
 				"@babel/plugin-proposal-async-generator-functions": "^7.10.4",
 				"@babel/plugin-proposal-class-properties": "^7.10.4",
 				"@babel/plugin-proposal-dynamic-import": "^7.10.4",
-				"@babel/plugin-proposal-export-namespace-from": "^7.10.4",
+				"@babel/plugin-proposal-export-namespace-from": "^7.12.0",
 				"@babel/plugin-proposal-json-strings": "^7.10.4",
-				"@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
-				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-				"@babel/plugin-proposal-numeric-separator": "^7.10.4",
+				"@babel/plugin-proposal-logical-assignment-operators": "^7.12.0",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.0",
+				"@babel/plugin-proposal-numeric-separator": "^7.12.0",
 				"@babel/plugin-proposal-object-rest-spread": "^7.11.0",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
-				"@babel/plugin-proposal-optional-chaining": "^7.11.0",
+				"@babel/plugin-proposal-optional-chaining": "^7.12.0",
 				"@babel/plugin-proposal-private-methods": "^7.10.4",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
 				"@babel/plugin-syntax-async-generators": "^7.8.0",
@@ -3305,7 +3315,7 @@
 				"@babel/plugin-transform-member-expression-literals": "^7.10.4",
 				"@babel/plugin-transform-modules-amd": "^7.10.4",
 				"@babel/plugin-transform-modules-commonjs": "^7.10.4",
-				"@babel/plugin-transform-modules-systemjs": "^7.10.4",
+				"@babel/plugin-transform-modules-systemjs": "^7.12.0",
 				"@babel/plugin-transform-modules-umd": "^7.10.4",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
 				"@babel/plugin-transform-new-target": "^7.10.4",
@@ -3322,11 +3332,9 @@
 				"@babel/plugin-transform-unicode-escapes": "^7.10.4",
 				"@babel/plugin-transform-unicode-regex": "^7.10.4",
 				"@babel/preset-modules": "^0.1.3",
-				"@babel/types": "^7.11.5",
+				"@babel/types": "^7.12.0",
 				"browserslist": "^4.12.0",
 				"core-js-compat": "^3.6.2",
-				"invariant": "^2.2.2",
-				"levenary": "^1.1.1",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
@@ -3379,9 +3387,9 @@
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -3434,18 +3442,18 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.0.tgz",
+			"integrity": "sha512-lS4QLXQ2Vbw2ubfQjeQcn+BZgZ5+ROHW9f+DWjEp5Y+NHYmkRGKqHSJ1tuhbUauKu2nhZNTBIvsIQ8dXfY5Gjw==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
-			"integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.0.tgz",
+			"integrity": "sha512-CltlJftStV4CBG4/HWVVRnBWFvLkYd22BkYO4gFgX+89JOlYiKQ5+Ji9Ovqb1o3T5DkkBn3JrVq1V/xweAaeGA==",
 			"dev": true,
 			"requires": {
 				"core-js-pure": "^3.0.0",
@@ -3526,9 +3534,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.12.5",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-					"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -3567,9 +3575,9 @@
 			}
 		},
 		"@irvingjs/babel-preset-irving": {
-			"version": "4.2.0-alpha.6",
-			"resolved": "https://registry.npmjs.org/@irvingjs/babel-preset-irving/-/babel-preset-irving-4.2.0-alpha.6.tgz",
-			"integrity": "sha512-juo/j2vlmPRwlkvuW6ini/nnaz6NDhL8+laYhkcTzcN6dNWoD/rm3AwVGZwNenXWyib0U+y1jca9SQfHEJjRhQ==",
+			"version": "5.1.0-alpha.1",
+			"resolved": "https://registry.npmjs.org/@irvingjs/babel-preset-irving/-/babel-preset-irving-5.1.0-alpha.1.tgz",
+			"integrity": "sha512-ZxG8eHyCBF6SRaz5+2UCS42FxG/SnjZ6IOuN61q/DKw1kwzNYUrbsg6DlhE5KZLUujfE/fgcr58WgbDzNiVQIg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.10.4",
@@ -3583,7 +3591,8 @@
 				"babel-plugin-lodash": "^3.3.4",
 				"babel-plugin-transform-globals": "^1.0.1",
 				"babel-plugin-universal-import": "^4.0.2",
-				"react-hot-loader": "^4.12.21"
+				"react-hot-loader": "^4.12.21",
+				"react-refresh": "^0.8.3"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -3596,19 +3605,19 @@
 					}
 				},
 				"@babel/core": {
-					"version": "7.11.6",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
-					"integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.0.tgz",
+					"integrity": "sha512-iV7Gwg0DePKvdDZZWRTkj4MW+6/AbVWd4ZCg+zk8H1RVt5xBpUZS6vLQWwb3pyLg4BFTaGiQCPoJ4Ibmbne4fA==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.11.6",
-						"@babel/helper-module-transforms": "^7.11.0",
+						"@babel/generator": "^7.12.0",
+						"@babel/helper-module-transforms": "^7.12.0",
 						"@babel/helpers": "^7.10.4",
-						"@babel/parser": "^7.11.5",
+						"@babel/parser": "^7.12.0",
 						"@babel/template": "^7.10.4",
-						"@babel/traverse": "^7.11.5",
-						"@babel/types": "^7.11.5",
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"convert-source-map": "^1.7.0",
 						"debug": "^4.1.0",
 						"gensync": "^1.0.0-beta.1",
@@ -3620,12 +3629,12 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.11.6",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-					"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.0.tgz",
+					"integrity": "sha512-8lnf4QcyiQMf5XQp47BltuMTocsOh6P0z/vueEh8GzhmWWlDbdvOoI5Ziddg0XYhmnx35HyByUW51/9NprF8cA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.5",
+						"@babel/types": "^7.12.0",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
@@ -3651,12 +3660,12 @@
 					}
 				},
 				"@babel/helper-member-expression-to-functions": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.0.tgz",
+					"integrity": "sha512-I0d/bgzgzgLsJMk7UZ0TN2KV3OGjC/t/9Saz8PKb9jrcEAXhgjGysOgp4PDKydIKjUv/gj2St4ae+ov8l+T9Xg==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.0"
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-module-imports": {
@@ -3669,17 +3678,19 @@
 					}
 				},
 				"@babel/helper-module-transforms": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-					"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.0.tgz",
+					"integrity": "sha512-1ZTMoCiLSzTJLbq7mSaTHki4oIrBIf/dUbzdhwTrvtMU3ZNVKwQmGae3gSiqppo7G8HAgnXmc43rfEaD8yYLLQ==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-imports": "^7.10.4",
-						"@babel/helper-replace-supers": "^7.10.4",
+						"@babel/helper-replace-supers": "^7.12.0",
 						"@babel/helper-simple-access": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.11.0",
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"lodash": "^4.17.19"
 					}
 				},
@@ -3693,15 +3704,15 @@
 					}
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.0.tgz",
+					"integrity": "sha512-9kycFdq2c9e7PXZOr2z/ZqTFF9OzFu287iFwYS+CiDVPuoTCfY8hoTsIqNQNetQjlqoRsRyJFrMG1uhGAR4EEw==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.10.4",
+						"@babel/helper-member-expression-to-functions": "^7.12.0",
 						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-simple-access": {
@@ -3752,9 +3763,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+					"integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -3769,26 +3780,26 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-					"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.0.tgz",
+					"integrity": "sha512-ZU9e79xpOukCNPkQ1UzR4gJKCruGckr6edd8v8lmKpSk8iakgUIvb+5ZtaKKV9f7O+x5r+xbMDDIbzVpUoiIuw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.11.5",
+						"@babel/generator": "^7.12.0",
 						"@babel/helper-function-name": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.11.5",
-						"@babel/types": "^7.11.5",
+						"@babel/parser": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -3805,14 +3816,15 @@
 			}
 		},
 		"@irvingjs/core": {
-			"version": "4.2.0-alpha.6",
-			"resolved": "https://registry.npmjs.org/@irvingjs/core/-/core-4.2.0-alpha.6.tgz",
-			"integrity": "sha512-Ju36djWm9jBlyaZoen9OSFOKNNze4DUDINJ8mgHRXK/BEbLGnJdsZUmTmlsJHI9mOFqYLjA0vVsZrggmac4GEg==",
+			"version": "5.1.0-alpha.1",
+			"resolved": "https://registry.npmjs.org/@irvingjs/core/-/core-5.1.0-alpha.1.tgz",
+			"integrity": "sha512-qGDcJ8GeABDpMb+/ge6HAEindc6UHcUUFCB5GVLW6fpaF7FfnNFLTBDn0rUx4TSCMlI/RrwFFXedxRHos0B3IA==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.10.4",
 				"@hot-loader/react-dom": "^16.13.0",
-				"@irvingjs/babel-preset-irving": "^4.2.0-alpha.6",
+				"@irvingjs/babel-preset-irving": "^5.1.0-alpha.1",
+				"@pmmmwh/react-refresh-webpack-plugin": "^0.4.2",
 				"@svgr/webpack": "^5.4.0",
 				"abort-controller": "^3.0.0",
 				"babel-eslint": "^10.1.0",
@@ -3860,6 +3872,7 @@
 				"react-hot-loader": "^4.12.21",
 				"react-oembed-container": "^1.0.0",
 				"react-redux": "^7.2.0",
+				"react-refresh": "^0.8.3",
 				"react-transition-group": "^4.4.1",
 				"react-universal-component": "^4.0.1",
 				"reduce-reducers": "^1.0.4",
@@ -3878,8 +3891,8 @@
 				"url-loader": "^4.1.0",
 				"url-parse": "^1.4.7",
 				"url-pattern": "^1.0.3",
-				"webpack": "^4.43.0",
-				"webpack-cli": "^3.3.11",
+				"webpack": "^4.44.2",
+				"webpack-cli": "^3.3.12",
 				"webpack-dev-middleware": "^3.7.2",
 				"webpack-flush-chunks": "^2.0.3",
 				"webpack-hot-middleware": "^2.25.0",
@@ -3899,19 +3912,19 @@
 					}
 				},
 				"@babel/core": {
-					"version": "7.11.6",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
-					"integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.0.tgz",
+					"integrity": "sha512-iV7Gwg0DePKvdDZZWRTkj4MW+6/AbVWd4ZCg+zk8H1RVt5xBpUZS6vLQWwb3pyLg4BFTaGiQCPoJ4Ibmbne4fA==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.11.6",
-						"@babel/helper-module-transforms": "^7.11.0",
+						"@babel/generator": "^7.12.0",
+						"@babel/helper-module-transforms": "^7.12.0",
 						"@babel/helpers": "^7.10.4",
-						"@babel/parser": "^7.11.5",
+						"@babel/parser": "^7.12.0",
 						"@babel/template": "^7.10.4",
-						"@babel/traverse": "^7.11.5",
-						"@babel/types": "^7.11.5",
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"convert-source-map": "^1.7.0",
 						"debug": "^4.1.0",
 						"gensync": "^1.0.0-beta.1",
@@ -3931,12 +3944,12 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.11.6",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-					"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.0.tgz",
+					"integrity": "sha512-8lnf4QcyiQMf5XQp47BltuMTocsOh6P0z/vueEh8GzhmWWlDbdvOoI5Ziddg0XYhmnx35HyByUW51/9NprF8cA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.5",
+						"@babel/types": "^7.12.0",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
@@ -3962,12 +3975,12 @@
 					}
 				},
 				"@babel/helper-member-expression-to-functions": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.0.tgz",
+					"integrity": "sha512-I0d/bgzgzgLsJMk7UZ0TN2KV3OGjC/t/9Saz8PKb9jrcEAXhgjGysOgp4PDKydIKjUv/gj2St4ae+ov8l+T9Xg==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.11.0"
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-module-imports": {
@@ -3980,17 +3993,19 @@
 					}
 				},
 				"@babel/helper-module-transforms": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-					"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.0.tgz",
+					"integrity": "sha512-1ZTMoCiLSzTJLbq7mSaTHki4oIrBIf/dUbzdhwTrvtMU3ZNVKwQmGae3gSiqppo7G8HAgnXmc43rfEaD8yYLLQ==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-imports": "^7.10.4",
-						"@babel/helper-replace-supers": "^7.10.4",
+						"@babel/helper-replace-supers": "^7.12.0",
 						"@babel/helper-simple-access": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.11.0",
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"lodash": "^4.17.19"
 					},
 					"dependencies": {
@@ -4012,15 +4027,15 @@
 					}
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.0.tgz",
+					"integrity": "sha512-9kycFdq2c9e7PXZOr2z/ZqTFF9OzFu287iFwYS+CiDVPuoTCfY8hoTsIqNQNetQjlqoRsRyJFrMG1uhGAR4EEw==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.10.4",
+						"@babel/helper-member-expression-to-functions": "^7.12.0",
 						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/traverse": "^7.12.0",
+						"@babel/types": "^7.12.0"
 					}
 				},
 				"@babel/helper-simple-access": {
@@ -4084,9 +4099,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+					"integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -4101,17 +4116,17 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-					"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.0.tgz",
+					"integrity": "sha512-ZU9e79xpOukCNPkQ1UzR4gJKCruGckr6edd8v8lmKpSk8iakgUIvb+5ZtaKKV9f7O+x5r+xbMDDIbzVpUoiIuw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.11.5",
+						"@babel/generator": "^7.12.0",
 						"@babel/helper-function-name": "^7.10.4",
 						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.11.5",
-						"@babel/types": "^7.11.5",
+						"@babel/parser": "^7.12.0",
+						"@babel/types": "^7.12.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
@@ -4126,9 +4141,9 @@
 					}
 				},
 				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"version": "7.12.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+					"integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.10.4",
@@ -4155,12 +4170,11 @@
 					},
 					"dependencies": {
 						"ansi-styles": {
-							"version": "4.2.1",
-							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-							"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+							"version": "4.3.0",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+							"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 							"dev": true,
 							"requires": {
-								"@types/color-name": "^1.1.1",
 								"color-convert": "^2.0.1"
 							}
 						},
@@ -4843,6 +4857,28 @@
 				}
 			}
 		},
+		"@pmmmwh/react-refresh-webpack-plugin": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.2.tgz",
+			"integrity": "sha512-Loc4UDGutcZ+Bd56hBInkm6JyjyCwWy4t2wcDXzN8EDPANgVRj0VP8Nxn0Zq2pc+WKauZwEivQgbDGg4xZO20A==",
+			"dev": true,
+			"requires": {
+				"ansi-html": "^0.0.7",
+				"error-stack-parser": "^2.0.6",
+				"html-entities": "^1.2.1",
+				"native-url": "^0.2.6",
+				"schema-utils": "^2.6.5",
+				"source-map": "^0.7.3"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+					"dev": true
+				}
+			}
+		},
 		"@redux-saga/core": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.1.3.tgz",
@@ -4987,9 +5023,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
+					"integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ==",
 					"dev": true
 				}
 			}
@@ -6343,12 +6379,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -6555,13 +6590,13 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.14.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.4.tgz",
-			"integrity": "sha512-7FOuawafVdEwa5Jv4nzeik/PepAjVte6HmVGHsjt2bC237jeL9QlcTBDF3PnHEvcC6uHwLGYPwZHNZMB7wWAnw==",
+			"version": "4.14.5",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.5.tgz",
+			"integrity": "sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==",
 			"dev": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001135",
-				"electron-to-chromium": "^1.3.570",
+				"electron-to-chromium": "^1.3.571",
 				"escalade": "^3.1.0",
 				"node-releases": "^1.1.61"
 			}
@@ -6679,9 +6714,9 @@
 			}
 		},
 		"cache-stampede": {
-			"version": "0.9.5",
-			"resolved": "https://registry.npmjs.org/cache-stampede/-/cache-stampede-0.9.5.tgz",
-			"integrity": "sha512-QJGF9W21VEPnN1Fib5neX94IkazvsrdT3fqOABRpXkVw5t5VS2wGTtZdU1PjPCZkSkmKMhHi0jLeVxtZila34g==",
+			"version": "0.9.6",
+			"resolved": "https://registry.npmjs.org/cache-stampede/-/cache-stampede-0.9.6.tgz",
+			"integrity": "sha512-P+wRx7FUE+ClEeNV3oN557kBnGn57tHphJnI2296aBz0Du5jlEJxkCsnVr5Linv/bri+Ixv/+czBl151hHlI1Q==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -6784,9 +6819,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001135",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz",
-			"integrity": "sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ==",
+			"version": "1.0.30001148",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
+			"integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -6836,12 +6871,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -6986,9 +7020,9 @@
 			}
 		},
 		"chokidar": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-			"integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+			"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
 			"dev": true,
 			"requires": {
 				"anymatch": "~3.1.1",
@@ -6998,7 +7032,7 @@
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
 				"normalize-path": "~3.0.0",
-				"readdirp": "~3.4.0"
+				"readdirp": "~3.5.0"
 			}
 		},
 		"chownr": {
@@ -7218,13 +7252,13 @@
 			}
 		},
 		"color": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-			"integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
+			"integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
 			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.1",
-				"color-string": "^1.5.2"
+				"color-string": "^1.5.4"
 			}
 		},
 		"color-convert": {
@@ -7243,9 +7277,9 @@
 			"dev": true
 		},
 		"color-string": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
-			"integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
+			"integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
 			"dev": true,
 			"requires": {
 				"color-name": "^1.0.0",
@@ -7631,9 +7665,9 @@
 			}
 		},
 		"css-what": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.3.0.tgz",
-			"integrity": "sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
+			"integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
 			"dev": true
 		},
 		"cssesc": {
@@ -8169,9 +8203,9 @@
 			}
 		},
 		"domhandler": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.1.0.tgz",
-			"integrity": "sha512-kZFobjdGafS1wknD9t0Ft+NazYYDxXNbcjqQ5z43xTq2FC1NT0U2QjgAmfc0C1urfeGDOAN2xzcKjifSbBpywg==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+			"integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
 			"dev": true,
 			"requires": {
 				"domelementtype": "^2.0.1"
@@ -8286,9 +8320,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.571",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.571.tgz",
-			"integrity": "sha512-UYEQ2Gtc50kqmyOmOVtj6Oqi38lm5yRJY3pLuWt6UIot0No1L09uu6Ja6/1XKwmz/p0eJFZTUZi+khd1PV1hHA==",
+			"version": "1.3.580",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.580.tgz",
+			"integrity": "sha512-5flHTbRpptO6h3lQUG4zdSAxryAS3PrZOkLpLS0DL5/y2LBf+l9HJ8X6UBorNs1QRBrMR7u/QvkdK+GlekW1kQ==",
 			"dev": true
 		},
 		"elliptic": {
@@ -8492,6 +8526,15 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
+		"error-stack-parser": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+			"integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+			"dev": true,
+			"requires": {
+				"stackframe": "^1.1.1"
+			}
+		},
 		"es-abstract": {
 			"version": "1.17.6",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
@@ -8540,9 +8583,9 @@
 			}
 		},
 		"escalade": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
-			"integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
 			"dev": true
 		},
 		"escape-goat": {
@@ -8625,9 +8668,9 @@
 			}
 		},
 		"eslint": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.9.0.tgz",
-			"integrity": "sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.11.0.tgz",
+			"integrity": "sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -8638,9 +8681,9 @@
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
 				"enquirer": "^2.3.5",
-				"eslint-scope": "^5.1.0",
+				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^2.1.0",
-				"eslint-visitor-keys": "^1.3.0",
+				"eslint-visitor-keys": "^2.0.0",
 				"espree": "^7.3.0",
 				"esquery": "^1.2.0",
 				"esutils": "^2.0.2",
@@ -8670,12 +8713,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -8702,6 +8744,12 @@
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"eslint-visitor-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+					"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
 					"dev": true
 				},
 				"globals": {
@@ -9030,9 +9078,9 @@
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.22.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
-			"integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
+			"version": "2.22.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+			"integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.1.1",
@@ -9040,7 +9088,7 @@
 				"contains-path": "^0.1.0",
 				"debug": "^2.6.9",
 				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "^0.3.3",
+				"eslint-import-resolver-node": "^0.3.4",
 				"eslint-module-utils": "^2.6.0",
 				"has": "^1.0.3",
 				"minimatch": "^3.0.4",
@@ -9095,16 +9143,16 @@
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.21.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.1.tgz",
-			"integrity": "sha512-TGtWzWrFjZtrD1giMz0O6a9ul++YR9vZSzIL/a7qlb5I/ra/O5RkMGMJK+KKYnJrzz884kyAkEyWiU4Hg2HTrg==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.4.tgz",
+			"integrity": "sha512-uHeQ8A0hg0ltNDXFu3qSfFqTNPXm1XithH6/SY318UX76CMj7Q599qWpgmMhVQyvhq36pm7qvoN3pb6/3jsTFg==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.1.1",
 				"array.prototype.flatmap": "^1.2.3",
 				"doctrine": "^2.1.0",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.4.1",
+				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
 				"object.entries": "^1.1.2",
 				"object.fromentries": "^2.0.2",
 				"object.values": "^1.1.1",
@@ -9167,9 +9215,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-					"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 					"dev": true
 				}
 			}
@@ -9803,15 +9851,27 @@
 			}
 		},
 		"file-loader": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.1.0.tgz",
-			"integrity": "sha512-26qPdHyTsArQ6gU4P1HJbAbnFTyT2r0pG7czh1GFAd9TZbj0n94wWbupgixZH/ET/meqi2/5+F7DhW4OAXD+Lg==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.1.1.tgz",
+			"integrity": "sha512-Klt8C4BjWSXYQAfhpYYkG4qHNTna4toMHEbWrI5IuVoxbU6uiDKeKAP99R8mmbJi3lvewn/jQBOgU4+NS3tDQw==",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^2.0.0",
-				"schema-utils": "^2.7.1"
+				"schema-utils": "^3.0.0"
 			},
 			"dependencies": {
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
 				"loader-utils": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
@@ -9821,6 +9881,17 @@
 						"big.js": "^5.2.2",
 						"emojis-list": "^3.0.0",
 						"json5": "^2.1.2"
+					}
+				},
+				"schema-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+					"integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.6",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
 					}
 				}
 			}
@@ -10887,14 +10958,14 @@
 					"dev": true
 				},
 				"domutils": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.0.tgz",
-					"integrity": "sha512-rP+tl0A3YekdmSpYOEtm4C/aSzwtEOU5XrkdoGwb+Hn/941f5S5kZwHr37AEIcBbPug3uxD8z9PKQZd1R/R/tg==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.2.tgz",
+					"integrity": "sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==",
 					"dev": true,
 					"requires": {
 						"dom-serializer": "^1.0.1",
 						"domelementtype": "^2.0.1",
-						"domhandler": "^3.1.0"
+						"domhandler": "^3.3.0"
 					}
 				}
 			}
@@ -10938,15 +11009,15 @@
 			}
 		},
 		"http-proxy-middleware": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.5.tgz",
-			"integrity": "sha512-CKzML7u4RdGob8wuKI//H8Ein6wNTEQR7yjVEzPbhBLGdOfkfvgTnp2HLnniKBDP9QW4eG10/724iTWLBeER3g==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.6.tgz",
+			"integrity": "sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==",
 			"dev": true,
 			"requires": {
 				"@types/http-proxy": "^1.17.4",
 				"http-proxy": "^1.18.1",
 				"is-glob": "^4.0.1",
-				"lodash": "^4.17.19",
+				"lodash": "^4.17.20",
 				"micromatch": "^4.0.2"
 			},
 			"dependencies": {
@@ -11215,15 +11286,6 @@
 			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
 			"dev": true
 		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
-		},
 		"ioredis": {
 			"version": "4.17.3",
 			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.17.3.tgz",
@@ -11243,9 +11305,9 @@
 			}
 		},
 		"ip-regex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-			"integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.2.0.tgz",
+			"integrity": "sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A==",
 			"dev": true
 		},
 		"ipaddr.js": {
@@ -13345,9 +13407,9 @@
 			}
 		},
 		"jest-worker": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
-			"integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+			"integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -13566,15 +13628,6 @@
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
 			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
 			"dev": true
-		},
-		"levenary": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
-			"integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
-			"dev": true,
-			"requires": {
-				"leven": "^3.1.0"
-			}
 		},
 		"levn": {
 			"version": "0.4.1",
@@ -14209,9 +14262,9 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+			"version": "2.14.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -14232,6 +14285,15 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
+			}
+		},
+		"native-url": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/native-url/-/native-url-0.2.6.tgz",
+			"integrity": "sha512-k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==",
+			"dev": true,
+			"requires": {
+				"querystring": "^0.2.0"
 			}
 		},
 		"natural-compare": {
@@ -14421,15 +14483,15 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.61",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
-			"integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
+			"version": "1.1.63",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.63.tgz",
+			"integrity": "sha512-ukW3iCfQaoxJkSPN+iK7KznTeqDGVJatAEuXsJERYHa9tn/KaT5lBdIyxQjLEVTzSkyjJEuQ17/vaEjrOauDkg==",
 			"dev": true
 		},
 		"nodemon": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.4.tgz",
-			"integrity": "sha512-Ltced+hIfTmaS28Zjv1BM552oQ3dbwPqI4+zI0SLgq+wpJhSyqgYude/aZa/3i31VCQWMfXJVxvu86abcam3uQ==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.5.tgz",
+			"integrity": "sha512-6/jqtZvJdk092pVnD2AIH19KQ9GQZAKOZVy/yT1ueL6aoV+Ix7a1lVZStXzvEh0fP4zE41DDWlkVoHjR6WlozA==",
 			"dev": true,
 			"requires": {
 				"chokidar": "^3.2.2",
@@ -14440,8 +14502,8 @@
 				"semver": "^5.7.1",
 				"supports-color": "^5.5.0",
 				"touch": "^3.1.0",
-				"undefsafe": "^2.0.2",
-				"update-notifier": "^4.0.0"
+				"undefsafe": "^2.0.3",
+				"update-notifier": "^4.1.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -14717,9 +14779,9 @@
 			}
 		},
 		"open": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/open/-/open-7.2.1.tgz",
-			"integrity": "sha512-xbYCJib4spUdmcs0g/2mK1nKo/jO2T7INClWd/beL7PFkXRWgr8B23ssDHX/USPn2M2IjDR5UdpYs6I67SnTSA==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-7.3.0.tgz",
+			"integrity": "sha512-mgLwQIx2F/ye9SmbrUkurZCnkoXyXyu9EbHtJZrICjVAJfyMArdHp3KkixGdZx1ZHFPNIwl0DDM1dFFqXbTLZw==",
 			"dev": true,
 			"requires": {
 				"is-docker": "^2.0.0",
@@ -15088,9 +15150,9 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "7.0.34",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.34.tgz",
-			"integrity": "sha512-H/7V2VeNScX9KE83GDrDZNiGT1m2H+UTnlinIzhjlLX9hfMUn1mHNnGeX81a1c8JSBdBvqk7c2ZOG6ZPn5itGw==",
+			"version": "7.0.35",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+			"integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
@@ -15116,9 +15178,9 @@
 			}
 		},
 		"postcss-calc": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.4.tgz",
-			"integrity": "sha512-0I79VRAd1UTkaHzY9w83P39YGO/M3bG7/tNLrHGEunBolfoGM0hSjrGvjoeaj0JE/zIw5GsI2KZ0UwDJqv5hjw==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.5.tgz",
+			"integrity": "sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.27",
@@ -15595,9 +15657,9 @@
 			}
 		},
 		"postcss-selector-parser": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.3.tgz",
-			"integrity": "sha512-0ClFaY4X1ra21LRqbW6y3rUbWcxnSVkDFG57R7Nxus9J9myPFlv+jYDMohzpkBx0RrjjiqjtycpchQ+PLGmZ9w==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+			"integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
 			"dev": true,
 			"requires": {
 				"cssesc": "^3.0.0",
@@ -15860,9 +15922,9 @@
 			"dev": true
 		},
 		"query-string": {
-			"version": "6.13.2",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.2.tgz",
-			"integrity": "sha512-BMmDaUiLDFU1hlM38jTFcRt7HYiGP/zt1sRzrIWm5zpeEuO1rkbPS0ELI3uehoLuuhHDCS8u8lhFN3fEN4JzPQ==",
+			"version": "6.13.5",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.5.tgz",
+			"integrity": "sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==",
 			"dev": true,
 			"requires": {
 				"decode-uri-component": "^0.2.0",
@@ -16237,6 +16299,12 @@
 				"react-is": "^16.9.0"
 			}
 		},
+		"react-refresh": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
+			"integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==",
+			"dev": true
+		},
 		"react-side-effect": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
@@ -16372,9 +16440,9 @@
 			}
 		},
 		"readdirp": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-			"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+			"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
 			"dev": true,
 			"requires": {
 				"picomatch": "^2.2.1"
@@ -17115,9 +17183,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.12.5",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-					"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -17343,23 +17411,41 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.18.0-next.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-					"integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+					"version": "1.18.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
 					"dev": true,
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.0",
+						"is-callable": "^1.2.2",
 						"is-negative-zero": "^2.0.0",
 						"is-regex": "^1.1.1",
 						"object-inspect": "^1.8.0",
 						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.0",
+						"object.assign": "^4.1.1",
 						"string.prototype.trimend": "^1.0.1",
 						"string.prototype.trimstart": "^1.0.1"
+					}
+				},
+				"is-callable": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+					"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.0",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
 					}
 				}
 			}
@@ -17679,6 +17765,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
 			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+			"dev": true
+		},
+		"stackframe": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+			"integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
 			"dev": true
 		},
 		"standard-as-callback": {
@@ -18511,9 +18603,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
 		"tty-browserify": {
@@ -18797,9 +18889,9 @@
 			"optional": true
 		},
 		"update-notifier": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.1.tgz",
-			"integrity": "sha512-9y+Kds0+LoLG6yN802wVXoIfxYEwh3FlZwzMwpCZp62S2i1/Jzeqb9Eeeju3NSHccGGasfGlK5/vEHbAifYRDg==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz",
+			"integrity": "sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==",
 			"dev": true,
 			"requires": {
 				"boxen": "^4.2.0",
@@ -18818,12 +18910,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -18903,16 +18994,28 @@
 			}
 		},
 		"url-loader": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.0.tgz",
-			"integrity": "sha512-IzgAAIC8wRrg6NYkFIJY09vtktQcsvU8V6HhtQj9PTefbYImzLB1hufqo4m+RyM5N3mLx5BqJKccgxJS+W3kqw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
+			"integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^2.0.0",
-				"mime-types": "^2.1.26",
-				"schema-utils": "^2.6.5"
+				"mime-types": "^2.1.27",
+				"schema-utils": "^3.0.0"
 			},
 			"dependencies": {
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
 				"loader-utils": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
@@ -18922,6 +19025,17 @@
 						"big.js": "^5.2.2",
 						"emojis-list": "^3.0.0",
 						"json5": "^2.1.2"
+					}
+				},
+				"schema-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+					"integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.6",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
 					}
 				}
 			}
@@ -19417,9 +19531,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+					"version": "6.4.2",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+					"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
 					"dev": true
 				},
 				"braces": {


### PR DESCRIPTION
This PR re-introduces a state variable, `canComment`, into the withPico HOC wrapper for Coral. Additionally, it adds the Irving log service to track the component's lifecycle for easier debugging.

The issue this corrects was due to the fact that there were instances where even when component variables pulled from the Redux store would update, this would not trigger the wrapper to re-render. This caused an issue where even though users would have a valid Pico payment tier and would have received a JWT token to log the user into the embed via SSO, the unauthenticated embed instance would persist in the DOM leaving the user logged out.

This behavior is corrected by the aforementioned state variable and a `useEffect` hook that uses the variables derived from the Pico signal, the Coral JWT token, and the status of the Coral user's username as dependencies. Any time one of these values changes the effect will be re-run, potentially changing the value of `canComment` and enforcing a component re-render to return the authenticated coral instance.