### PR TITLE
fix(html.js): adds sub and sup to allowed html tags

### DIFF
--- a/packages/core/config/html.js
+++ b/packages/core/config/html.js
@@ -4,7 +4,8 @@ export const richText = {
     'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'code', 'cite', 'hr', 'br',
     'div', 'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre', 'img',
     'figure', 'figcaption', 'iframe', 'audio', 'video', 'time', 'article',
-    'section', 'aside', 'footer', 'header', 'nav', 'button', 'link',
+    'section', 'aside', 'footer', 'header', 'nav', 'button', 'link', 'sub',
+    'sup',
   ],
   allowedAttributes: {
     '*': ['class', 'id', 'data-*', 'style'],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please be sure to review the guide for [contributing to this repo](https://github.com/alleyinteractive/irving/blob/main/CONTRIBUTING.md) and be sure you are following all guidelines.
-->

## Issue(s): Relates to or closes...

https://alleyinteractive.atlassian.net/browse/LEDE-566

## Summary: This pull request will...

Add `sub` and `sup` to the list of allowed richText tags in html.js.

## Tests: I know this code works because...

Tested locally.
