### PR TITLE
Fix styled components component map logic

### DIFF
--- a/packages/styled-components/componentMap.js
+++ b/packages/styled-components/componentMap.js
@@ -104,16 +104,18 @@ export const defaultMapping = {
  * @return {object}
  */
 const createThemedComponentMap = (userThemesToInject) => {
-  // Loop through the `userThemesToInject` object
-  const userMapping = Object.keys(userThemesToInject)
+  const componentMapWithThemes = Object.keys(components)
     .reduce((acc, componentName) => {
       const {
         themeMap,
         Component,
       } = components[componentName];
+
+      const userThemes = userThemesToInject[componentName] || {};
+
       const mergedThemeMap = {
         ...themeMap,
-        ...userThemesToInject[componentName],
+        ...userThemes,
       };
 
       return {
@@ -124,7 +126,7 @@ const createThemedComponentMap = (userThemesToInject) => {
 
   return {
     ...defaultMapping,
-    ...userMapping,
+    ...componentMapWithThemes,
   };
 };
 


### PR DESCRIPTION
## Issue(s): Relates to or closes...
No ticket.

## Summary: This pull request will...
Fix a bug with `createThemedComponentMap` where component themes in the `@irvingjs/styled-components` package weren't being included unless a custom theme was being set.

## Tests: I know this code works because...
Tested locally.