### PR TITLE
Update `html` theme on `irving/text` to not distort images

### DIFF
--- a/packages/styled-components/components/text/themes/html.js
+++ b/packages/styled-components/components/text/themes/html.js
@@ -391,6 +391,7 @@ export const TextWrapper = styled.div`
 
   img,
   figure {
+    height: auto;
     max-width: 100%;
   }
 `;


### PR DESCRIPTION
## Issue(s): Relates to or closes...
None.

## Summary: This pull request will...
Add a `height: auto;` property to the `irving/text` `html` theme, preventing images from being distorted.

Without `height: auto;`,
<img width="497" alt="Screen Shot 2020-12-15 at 4 49 41 PM" src="https://user-images.githubusercontent.com/665107/102282082-aa4cc680-3ef5-11eb-9803-6a05694ca6e6.png">

Including `height: auto;`,
<img width="500" alt="Screen Shot 2020-12-15 at 4 49 54 PM" src="https://user-images.githubusercontent.com/665107/102282121-b5075b80-3ef5-11eb-964e-4b864a74a871.png">

## Tests: I know this code works because...
Tested locally.