### PR TITLE
fix(loadable): use prefetch instead of preload for async chunks

### DIFF
--- a/packages/core/config/paths.js
+++ b/packages/core/config/paths.js
@@ -64,6 +64,7 @@ module.exports = {
   config: resolveAppDir('irving.config.js'),
   globalStyles: resolveIrvingDir('assets/styles'),
   irvingRoot,
+  localRoot: path.join(__dirname, '../../../'),
   mocks: resolveIrvingDir('__mocks__'),
   nodeModules: resolveIrvingDir('node_modules'),
   postCssConfig: resolveIrvingDir('config/postcss.config.js'),

--- a/packages/core/config/webpack/alias.js
+++ b/packages/core/config/webpack/alias.js
@@ -19,6 +19,7 @@ module.exports = function getAlias(context) {
         'react-dom': path.join(appRoot, './node_modules/react-dom'),
         react: path.join(appRoot, './node_modules/react'),
         'react-redux': path.join(appRoot, './node_modules/react-redux'),
+        'prop-types': path.join(appRoot, './node_modules/prop-types'),
         'styled-components': path.join(
           appRoot,
           './node_modules/styled-components'

--- a/packages/loadable/server/getAppTemplateVars.js
+++ b/packages/loadable/server/getAppTemplateVars.js
@@ -23,8 +23,8 @@ export default function getAppTemplateVars(templateVars) {
            *  loadable components seems to enforce
            */
           extractor.getLinkTags().replace(
-            /rel="preload"/gi,
-            'rel="prefetch"'
+            /(data-chunk="[^"]+"\srel=)("preload")(\sas="[^"]+")/gi,
+            '$1"prefetch"'
           )
         ),
         style: () => extractor.getStyleTags(),

--- a/packages/loadable/server/getAppTemplateVars.js
+++ b/packages/loadable/server/getAppTemplateVars.js
@@ -16,8 +16,17 @@ export default function getAppTemplateVars(templateVars) {
     return {
       Wrapper: () => extractor.collectChunks(<Wrapper />),
       head: {
-        end: () => extractor.getScriptTags(),
-        link: () => extractor.getLinkTags(),
+        script: () => extractor.getScriptTags(),
+        link: () => (
+          /**
+           *  @todo find a better way to get rid of the auto-preloading that
+           *  loadable components seems to enforce
+           */
+          extractor.getLinkTags().replace(
+            /rel="preload"/gi,
+            'rel="prefetch"'
+          )
+        ),
         style: () => extractor.getStyleTags(),
       },
     };

--- a/packages/styled-components/components/byline/themes/default.js
+++ b/packages/styled-components/components/byline/themes/default.js
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 
 /* eslint-disable import/prefer-default-export */
 export const BylineWrapper = styled.div`
-  display: flex;
   flex-direction: column;
+  display: flex;
   white-space: pre;
   width: 100%;
 `;

--- a/packages/styled/config/stylelint.config.js
+++ b/packages/styled/config/stylelint.config.js
@@ -1,7 +1,11 @@
+const path = require('path');
 const {
   getValueFromFiles,
 } = require('@irvingjs/core/config/irving/getValueFromFiles');
-const { buildContext } = require('@irvingjs/core/config/paths');
+const {
+  buildContext,
+  localRoot,
+} = require('@irvingjs/core/config/paths');
 const propertyOrder = require('./stylelintPropertyOrder');
 
 const baseConfig = {
@@ -13,6 +17,10 @@ const baseConfig = {
   ],
   extends: [
     'stylelint-config-styled-components',
+  ],
+  ignoreFiles: [
+    path.join(localRoot, '**/*.js'),
+    path.join(buildContext, 'node_modules/**/*.js'),
   ],
   rules: {
     'at-rule-empty-line-before': ['always', {

--- a/packages/wordpress/components/blockStyles/blocks/heading.js
+++ b/packages/wordpress/components/blockStyles/blocks/heading.js
@@ -4,7 +4,7 @@ import { link } from './utils';
 /* eslint-disable indent */
 const heading = css`
   color: #000000;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Arial", "Helvetica", sans-serif;
   font-size: 1rem;
   font-weight: 700;
   line-height: 1.3;
@@ -15,6 +15,7 @@ const heading = css`
 `;
 
 export const headingBlock = css`
+
   [data-type="core/heading"] {
     ${heading}
   }

--- a/packages/wordpress/components/blockStyles/blocks/image.js
+++ b/packages/wordpress/components/blockStyles/blocks/image.js
@@ -2,6 +2,7 @@ import { css } from 'styled-components';
 import { bodyText, caption, link } from './utils';
 
 export const imageBlock = css`
+
   .wp-block-image {
     ${bodyText};
 

--- a/packages/wordpress/components/blockStyles/blocks/index.js
+++ b/packages/wordpress/components/blockStyles/blocks/index.js
@@ -53,10 +53,14 @@ const getBlockMap = () => {
             ${userStyles};
           `;
         } else {
-          coreStyles = css`${userStyles}`;
+          coreStyles = css`
+            ${userStyles}
+          `;
         }
       } else {
-        coreStyles = css`${defaultStyles}`;
+        coreStyles = css`
+          ${defaultStyles}
+        `;
       }
 
       return {

--- a/packages/wordpress/components/blockStyles/blocks/latestPosts.js
+++ b/packages/wordpress/components/blockStyles/blocks/latestPosts.js
@@ -1,7 +1,9 @@
 import { css } from 'styled-components';
 import { link, list, listItem } from './utils';
 
+/* stylelint-disable selector-max-specificity */
 export const latestPostsBlock = css`
+
   [data-type="core/latest-posts"] ul,
   .wp-block-latest-posts,
   .wp-block-latest-posts.wp-block-latest-posts__list {
@@ -23,3 +25,4 @@ export const latestPostsBlock = css`
     }
   }
 `;
+/* stylelint-enable */

--- a/packages/wordpress/components/blockStyles/blocks/list.js
+++ b/packages/wordpress/components/blockStyles/blocks/list.js
@@ -2,6 +2,7 @@ import { css } from 'styled-components';
 import { link, list, listItem } from './utils';
 
 export const listBlock = css`
+
   [data-type="core/list"],
   .irving__post-content ul,
   .irving__post-content ol {

--- a/packages/wordpress/components/blockStyles/blocks/mediaText.js
+++ b/packages/wordpress/components/blockStyles/blocks/mediaText.js
@@ -1,6 +1,7 @@
 import { css } from 'styled-components';
 
 export const mediaTextBlock = css`
+
   .wp-block-media-text {
 
     img {

--- a/packages/wordpress/components/blockStyles/blocks/paragraph.js
+++ b/packages/wordpress/components/blockStyles/blocks/paragraph.js
@@ -1,7 +1,9 @@
 import { css } from 'styled-components';
 import { bodyText, link } from './utils';
 
+/* stylelint-disable selector-max-specificity */
 export const paragraphBlock = css`
+
   [data-type="core/paragraph"],
   .irving__post-content p {
     ${bodyText};
@@ -10,9 +12,10 @@ export const paragraphBlock = css`
       ${link};
     }
 
-    &.has-drop-cap:first-letter {
+    &.has-drop-cap::first-letter {
       font-size: 5rem;
       font-weight: 700;
     }
   }
 `;
+/* stylelint-enable */

--- a/packages/wordpress/components/blockStyles/blocks/pullquote.js
+++ b/packages/wordpress/components/blockStyles/blocks/pullquote.js
@@ -3,6 +3,7 @@ import { link } from './utils';
 
 /* eslint-disable indent */
 export const pullquoteBlock = css`
+
   .wp-block-pullquote {
     display: flex;
     padding: 1rem 1.5rem;
@@ -11,7 +12,7 @@ export const pullquoteBlock = css`
     &::before {
       color: #AAAAAA;
       content: '“';
-      font-family: 'Times New Roman', Times, serif;
+      font-family: "Times New Roman", "Times", serif;
       font-size: 4rem;
       font-weight: 700;
       margin-right: 1.5rem;
@@ -19,15 +20,15 @@ export const pullquoteBlock = css`
 
     p {
       color: #000000;
-      font-family: Arial, Helvetica, sans-serif;
+      font-family: "Arial", "Helvetica", sans-serif;
       font-size: 1rem;
       font-weight: 400;
     }
 
     cite {
-      display: inline-block;
       color: #000000;
-      font-family: Times, Georgia, serif;
+      display: inline-block;
+      font-family: "Times", "Georgia", serif;
       font-size: 0.75rem;
       font-weight: 400;
       margin-top: 2rem;

--- a/packages/wordpress/components/blockStyles/blocks/quote.js
+++ b/packages/wordpress/components/blockStyles/blocks/quote.js
@@ -3,6 +3,7 @@ import { link } from './utils';
 
 /* eslint-disable indent */
 export const quoteBlock = css`
+
   .wp-block-quote {
     border-left: 1px solid black;
     display: flex;
@@ -18,15 +19,15 @@ export const quoteBlock = css`
 
     p {
       color: #000000;
-      font-family: Arial, Helvetica, sans-serif;
+      font-family: "Arial", "Helvetica", sans-serif;
       font-size: 1rem;
       font-weight: 400;
     }
 
     cite {
-      display: inline-block;
       color: #000000;
-      font-family: Times, Georgia, serif;
+      display: inline-block;
+      font-family: "Times", "Georgia", serif;
       font-size: 0.75rem;
       font-weight: 400;
       margin-top: 2rem;

--- a/packages/wordpress/components/blockStyles/blocks/separator.js
+++ b/packages/wordpress/components/blockStyles/blocks/separator.js
@@ -1,6 +1,7 @@
 import { css } from 'styled-components';
 
 export const separatorBlock = css`
+
   .wp-block-separator {
     width: 100%;
   }

--- a/packages/wordpress/components/blockStyles/blocks/table.js
+++ b/packages/wordpress/components/blockStyles/blocks/table.js
@@ -3,6 +3,7 @@ import { bodyText, link, caption } from './utils';
 
 /* eslint-disable indent */
 export const tableBlock = css`
+
   .wp-block-table {
     ${bodyText};
 

--- a/packages/wordpress/components/blockStyles/blocks/utils/link.js
+++ b/packages/wordpress/components/blockStyles/blocks/utils/link.js
@@ -3,8 +3,8 @@ import { siteTheme } from '@irvingjs/styled/utils';
 
 /* eslint-disable max-len, indent */
 const link = css`
-  color: ${siteTheme('blocks.link.color', 'inherit')};
   border: ${siteTheme('blocks.link.border', 'inherit')};
+  color: ${siteTheme('blocks.link.color', 'inherit')};
   font-family: ${siteTheme(
     'blocks.link.fontFamily',
     'Arial, Helvetica, sans-serif'

--- a/packages/wordpress/components/blockStyles/blocks/video.js
+++ b/packages/wordpress/components/blockStyles/blocks/video.js
@@ -3,6 +3,7 @@ import caption from './utils/caption';
 import link from './utils/link';
 
 export const videoBlock = css`
+
   .wp-block-video {
 
     figcaption {


### PR DESCRIPTION
## Issue(s): Relates to or closes...
[**LEDE-528**](https://alleyinteractive.atlassian.net/browse/LEDE-528)

## Summary: This pull request will...
* Switch all async chunks to using a `rel="prefetch"` link instead of `rel="preload"`. Still not 100% sure why this is necessary, but it seems to resolve the issue.

## Tests: I know this code works because...
* Tested on client project
