### PR TITLE
perf(core): Upgrade sanitize-html to 2.3.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,7 +97,7 @@
     "redux-saga": "^1.1.3",
     "regenerator-runtime": "^0.13.5",
     "reselect": "^3.0.1",
-    "sanitize-html": "^1.23.0",
+    "sanitize-html": "^2.3.0",
     "source-map-support": "^0.5.19",
     "style-loader": "^0.21.0",
     "terser-webpack-plugin": "^3.0.3",


### PR DESCRIPTION
The latest release of sanitize-html is a much smaller package size, and should improve performance
overall.

We were previously using versions ^1.23.0, which was 1.62 MB unpacked. Version 2.3.0 is reported as being 67.2 kB since they removed built files (including polyfills) in version 2.0.