### PR TITLE
feat(groupchildren utility): adds a groupChildren uility to core

### DIFF
--- a/packages/core/utils/children.js
+++ b/packages/core/utils/children.js
@@ -49,3 +49,30 @@ export const filterChildren = (prop, value, children) => (
 export const filterChildrenByName = (componentName, children) => (
   filterChildren('componentName', componentName, children)
 );
+
+/**
+ * Map an array of children into an object using the `group` prop.`
+ *
+ * @param {array} children An array of React components.
+ * @returns {object} Mapping of children by group.
+ */
+export const groupChildren = (children) => {
+  const mapping = {
+    rest: [], // Array containing ungrouped children.
+  };
+
+  // If the `group` prop exists, and the group has been allow-listed, push the
+  // child component.
+  children.forEach((child) => {
+    const { group } = child.props;
+
+    if (group) {
+      const currentGroup = mapping[group] || [];
+      mapping[group] = currentGroup.concat(child);
+    } else {
+      mapping.rest = mapping.rest.concat(child);
+    }
+  });
+
+  return mapping;
+};

--- a/packages/core/utils/children.js
+++ b/packages/core/utils/children.js
@@ -58,7 +58,7 @@ export const filterChildrenByName = (componentName, children) => (
  */
 export const groupChildren = (children) => {
   const mapping = {
-    rest: [], // Array containing ungrouped children.
+    ungrouped: [], // Array containing ungrouped children.
   };
 
   // If the `group` prop exists, and the group has been allow-listed, push the
@@ -70,7 +70,7 @@ export const groupChildren = (children) => {
       const currentGroup = mapping[group] || [];
       mapping[group] = currentGroup.concat(child);
     } else {
-      mapping.rest = mapping.rest.concat(child);
+      mapping.ungrouped = mapping.ungrouped.concat(child);
     }
   });
 

--- a/packages/core/utils/children.test.js
+++ b/packages/core/utils/children.test.js
@@ -3,6 +3,7 @@ import {
   findChildByName,
   filterChildren,
   filterChildrenByName,
+  groupChildren,
 } from './children';
 
 const testElement = {
@@ -79,4 +80,75 @@ it('should filter an array of react elements by api component name', () => {
       },
     },
   ]);
+});
+
+const testGroupChildrenElement = {
+  props: {},
+  children: [
+    {
+      props: {
+        componentName: 'foo',
+        testProp: 'bar',
+        group: 'first'
+      },
+    },
+    {
+      props: {
+        componentName: 'lorem',
+        testProp: 'baz',
+        group: 'first'
+      },
+    },
+    {
+      props: {
+        componentName: 'lorem',
+        testProp: 'bar',
+        group: 'second'
+      },
+    },
+    {
+      props: {
+        componentName: 'lorem',
+        testProp: 'hello world'
+      },
+    },
+  ],
+};
+
+it('should return an object of children mapped to an object by the value of the group key', () => {
+  expect(groupChildren(testGroupChildrenElement.children)).toEqual({
+    first: [
+      {
+        props: {
+          componentName: 'foo',
+          testProp: 'bar',
+          group: 'first'
+        },
+      },
+      {
+        props: {
+          componentName: 'lorem',
+          testProp: 'baz',
+          group: 'first'
+        },
+      },
+    ],
+    second: [
+      {
+        props: {
+          componentName: 'lorem',
+          testProp: 'bar',
+          group: 'second'
+        },
+      },
+    ],
+    rest: [
+      {
+        props: {
+          componentName: 'lorem',
+          testProp: 'hello world'
+        },
+      },
+    ],
+  });
 });

--- a/packages/core/utils/children.test.js
+++ b/packages/core/utils/children.test.js
@@ -142,7 +142,7 @@ it('should return an object of children mapped to an object by the value of the 
         },
       },
     ],
-    rest: [
+    ungrouped: [
       {
         props: {
           componentName: 'lorem',


### PR DESCRIPTION
This utility returns an object where the components are mapped by the group prop/config value.

## Issue(s): Relates to or closes...
https://alleyinteractive.atlassian.net/browse/IRV-726

## Summary: This pull request will...
Add a utility which maps an array of children into an object using each child's `group` prop.

## Example
```
const components = [
  {
    name: "irving/example-a",
    config: {
      "group": "first",
    },
  },
  {
    name: "irving/example-b",
    config: {
      "group": "first",
    },
  },
  {
    name: "irving/example-c",
    config: {
      "group": "second",
    },
  },
  {
    name: "irving/example-d",
  },
];

const groups = groupChildren(components);

console.log(groups);
```

Output:
```
{
  first: [
    {
      name: "irving/example-a",
      config: {
        "group": "first",
      },
    },
    {
      name: "irving/example-b",
      config: {
        "group": "first",
      },
    },
  ],
  second: [
    {
      name: "irving/example-c",
      config: {
        "group": "second",
      },
    },
  ],
  rest: [
    {
      name: "irving/example-d",
    }
  ]
}
```


## Tests: I know this code works because...
This utility has been battle tested on a few projects, and has unit tests.