### PR TITLE
Update site-menu.stories.mdx

### DIFF
--- a/stories/13-wordpress-components/site-menu.stories.mdx
+++ b/stories/13-wordpress-components/site-menu.stories.mdx
@@ -26,7 +26,7 @@ This component uses the `location` config value with `get_nav_menu_locations()` 
   },
   "menu_name": {
     "type": "string",
-    "default": "Default"
+    "default": ""
   }
 }
 ```


### PR DESCRIPTION
## Issue(s): Relates to or closes...
https://alleyinteractive.atlassian.net/browse/IRV-882

## Summary: This pull request will...
As per https://github.com/alleyinteractive/wp-irving/pull/307, the default value for `menu_name` is no longer `"Default"`.

## Tests: I know this code works because...
Only a documentation update.