### PR TITLE
Fix body wrapper and loader components so they're actually configurable

### DIFF
--- a/packages/core/config/webpack/plugins.js
+++ b/packages/core/config/webpack/plugins.js
@@ -104,7 +104,6 @@ module.exports = function getPlugins(context, argv) {
           filename: '[name].css',
           chunkFilename: '[id].css',
         }),
-
       ];
 
     default:

--- a/packages/styled-components/componentMap.js
+++ b/packages/styled-components/componentMap.js
@@ -8,6 +8,7 @@ import * as Container from 'components/container';
 import * as Fragment from 'components/fragment';
 import * as Image from 'components/image';
 import * as Link from 'components/link';
+import * as Loader from 'components/loader';
 import * as Logo from 'components/logo';
 import * as Menu from 'components/menu';
 import * as Pagination from 'components/pagination';
@@ -56,6 +57,7 @@ export const components = {
   'irving/social-links': SocialLinks,
   'irving/social-sharing': SocialSharing,
   'irving/text': Text,
+  'irving/loader': Loader,
 };
 
 export const defaultIcons = {
@@ -82,6 +84,7 @@ export const defaultMapping = {
   'irving/header-wrapper': Fragment.Component,
   'irving/image': Image.Component,
   'irving/link': Link.Component,
+  'irving/loader': Loader.Component,
   'irving/logo': Logo.Component,
   'irving/menu': Menu.Component,
   'irving/pagination': Pagination.Component,

--- a/packages/styled-components/components/bodyWrapper/index.js
+++ b/packages/styled-components/components/bodyWrapper/index.js
@@ -1,22 +1,33 @@
 import React from 'react';
-import Loader from 'components/loader';
+import PropTypes from 'prop-types';
+import {
+  Component as LoaderComponent,
+  themeMap as loaderThemeMap,
+} from 'components/loader';
 import useStandardProps from '@irvingjs/styled/hooks/useStandardProps';
+import withThemes from '@irvingjs/styled/components/hoc/withThemes';
 import {
   standardPropTypes,
   getStandardDefaultProps,
 } from '@irvingjs/styled/types/propTypes';
 import * as defaultStyles from './themes/default';
 
+const Loader = withThemes(loaderThemeMap)(LoaderComponent);
+
 const BodyWrapper = (props) => {
   const {
     children,
     theme,
+    loadingProps,
   } = props;
   const standardProps = useStandardProps(props);
   const { Main } = theme;
 
   return (
-    <Loader>
+    <Loader
+      theme={theme}
+      loadingProps={loadingProps}
+    >
       <Main
         {...standardProps}
         id="content"
@@ -29,11 +40,16 @@ const BodyWrapper = (props) => {
 
 BodyWrapper.propTypes = {
   ...standardPropTypes,
+  /**
+   * Props passed to Loader component.
+   */
+  loadingProps: PropTypes.object,
 };
 
 BodyWrapper.defaultProps = {
   ...getStandardDefaultProps(),
   theme: defaultStyles,
+  loadingProps: {},
 };
 
 const themeMap = {

--- a/packages/styled-components/components/loader/defaultLoading.js
+++ b/packages/styled-components/components/loader/defaultLoading.js
@@ -5,8 +5,6 @@ import Spinner from './spinner';
 const DefaultLoading = (props) => {
   const {
     className,
-    fullScreen,
-    fullScreenBgColor,
     children,
     spinnerProps,
     theme,
@@ -17,8 +15,6 @@ const DefaultLoading = (props) => {
     <LoadingWrapper
       data-testid="loading"
       className={className}
-      fullScreen={fullScreen}
-      style={{ backgroundColor: fullScreenBgColor }}
     >
       {children || (
         <Spinner
@@ -32,8 +28,6 @@ const DefaultLoading = (props) => {
 
 DefaultLoading.defaultProps = {
   className: '',
-  fullScreen: false,
-  fullScreenBgColor: '#FFF',
   children: false,
   spinnerProps: {},
 };
@@ -44,16 +38,6 @@ DefaultLoading.propTypes = {
    * default: ''
    */
   className: PropTypes.string,
-  /**
-   * Whether or not the loader component should cover the entire screen.
-   * default: false
-   */
-  fullScreen: PropTypes.bool,
-  /**
-   * Background color for full screen loader
-   * default: `#FFF`
-   */
-  fullScreenBgColor: PropTypes.string,
   /**
    * Allows for defining a custom component to be displayed for the loading state.
    * default: null (<Spinner />)

--- a/packages/styled-components/components/loader/index.js
+++ b/packages/styled-components/components/loader/index.js
@@ -48,7 +48,7 @@ const Loader = (props) => {
               type={transition.type}
               style={transitionStyle}
             >
-              {! loading ? (
+              {loading ? (
                 <LoadingComponent
                   {...standardProps}
                   {...loadingProps}

--- a/packages/styled-components/components/loader/index.js
+++ b/packages/styled-components/components/loader/index.js
@@ -29,7 +29,6 @@ const Loader = (props) => {
     Wrapper,
   } = theme;
   const loading = useLoading();
-  /* eslint-disable */
 
   return (
     <>

--- a/packages/styled-components/components/loader/index.js
+++ b/packages/styled-components/components/loader/index.js
@@ -29,6 +29,7 @@ const Loader = (props) => {
     Wrapper,
   } = theme;
   const loading = useLoading();
+  /* eslint-disable */
 
   return (
     <>
@@ -47,7 +48,7 @@ const Loader = (props) => {
               type={transition.type}
               style={transitionStyle}
             >
-              {loading ? (
+              {! loading ? (
                 <LoadingComponent
                   {...standardProps}
                   {...loadingProps}
@@ -79,6 +80,10 @@ const Loader = (props) => {
 Loader.propTypes = {
   ...standardPropTypes,
   /**
+   * Name of the component
+   */
+  componentName: PropTypes.string,
+  /**
    * Transition characteristics.
    */
   transition: PropTypes.shape({
@@ -100,6 +105,9 @@ Loader.propTypes = {
 
 Loader.defaultProps = {
   ...getStandardDefaultProps(),
+  // this component is sometimes used independent of the component map,
+  // so we're making sure component name classes still get added.
+  componentName: 'irving/loader',
   theme: defaultStyles,
   transition: {
     enabled: true,

--- a/packages/styled-components/components/loader/themes/default.js
+++ b/packages/styled-components/components/loader/themes/default.js
@@ -27,18 +27,10 @@ export const Wrapper = styled.div``;
 
 export const LoadingWrapper = styled.div`
   align-items: center;
+  background-color: #FFF;
   display: flex;
   justify-content: center;
   padding: 4rem;
-
-  ${(props) => (
-    props.fullScreen ? `
-      height: 100%;
-      position: fixed;
-      width: 100%;
-      z-index: 1000;
-    ` : ''
-  )};
 `;
 
 export const SpinnerIcon = styled(SpinnerSVG)`

--- a/packages/styled/components/hoc/withThemes.js
+++ b/packages/styled/components/hoc/withThemes.js
@@ -4,10 +4,16 @@ import assign from 'lodash/fp/assign';
 
 const withThemes = (themeMap) => (WrappedComponent) => {
   const ThemedComponent = (props) => {
-    const { themeName } = props;
+    const {
+      theme: propsTheme,
+      themeName,
+    } = props;
+    const currentTheme = propsTheme && Object.keys(propsTheme).length ?
+      propsTheme :
+      themeMap[themeName] || {};
     const theme = assign(
       themeMap.default,
-      themeMap[themeName]
+      currentTheme
     );
 
     return (
@@ -23,10 +29,15 @@ const withThemes = (themeMap) => (WrappedComponent) => {
      * Prop indicating which theme to use.
      */
     themeName: PropTypes.oneOf(Object.keys(themeMap)),
+    /**
+     * Theme (styles) to apply to the component.
+     */
+    theme: PropTypes.object,
   };
 
   ThemedComponent.defaultProps = {
     themeName: 'default',
+    theme: {},
   };
 
   return ThemedComponent;

--- a/packages/styled/types/propTypes.js
+++ b/packages/styled/types/propTypes.js
@@ -43,6 +43,10 @@ export const standardPropTypes = {
    * Theme (styles) to apply to the component.
    */
   theme: PropTypes.object,
+  /**
+   * Name of theme to apply to component.
+   */
+  themeName: PropTypes.string,
 };
 
 export const getStandardDefaultProps = () => ({
@@ -51,4 +55,5 @@ export const getStandardDefaultProps = () => ({
   className: '',
   style: {},
   tag: '',
+  themeName: 'default',
 });


### PR DESCRIPTION
## Issue(s): Relates to or closes...
[**LEDE-1187**](https://alleyinteractive.atlassian.net/browse/LEDE-1187)

## Summary: This pull request will...
* Add the loader component to the component map.
* Deprecate/remove the `fullScreen` and `fullScreenBgColor` options for the loader component as they are too prescriptive and difficult to override. We can add it back in later as a theme, if necessary.
* Allow a theme for the `BodyWrapper` component to cascade down and theme the `Loader` and `DefaultLoader` components as well.
* Add functionality to `withThemes` to allow passing in a theme directly to a component as a prop. This prop theme will take precedence over a `themeName`.

## Tests: I know this code works because...
Tested locally on client projects
