### PR TITLE
Add visited flag in redux to prevent multiple visit calls on a single navigation

### DIFF
--- a/packages/integrations/components/pico/index.js
+++ b/packages/integrations/components/pico/index.js
@@ -16,6 +16,7 @@ import {
 import {
   picoLifecycleSelector,
   picoContentReadySelector,
+  picoVisitedSelector,
 } from '../../selectors/picoSelector';
 // Utility functions.
 import {
@@ -64,6 +65,7 @@ const Pico = (props) => {
     ready: picoReady,
   } = useSelector(picoLifecycleSelector);
   const contentReady = useSelector(picoContentReadySelector);
+  const visited = useSelector(picoVisitedSelector);
 
   // Add lifecycle listeners.
   usePicoEventListeners();
@@ -81,6 +83,7 @@ const Pico = (props) => {
     if (
       ! irvingIsLoading &&
       scriptOnload &&
+      ! visited &&
       (
         (contentReady && picoPageInfo.article) ||
         ! picoPageInfo.article

--- a/packages/integrations/reducers/defaultState.js
+++ b/packages/integrations/reducers/defaultState.js
@@ -5,12 +5,9 @@ export const manager = {
 
 export const pico = {
   contentReady: false,
-  isInitialized: false,
-  isLoaded: false,
-  isReady: false,
-  isUpdated: false,
   signal: {},
   pageInfo: {},
+  visited: false,
   lifecycle: {
     scriptAdded: false,
     scriptOnload: false,

--- a/packages/integrations/reducers/picoReducer.js
+++ b/packages/integrations/reducers/picoReducer.js
@@ -37,12 +37,13 @@ export default function picoReducer(
       return {
         ...state,
         contentReady: false,
-        isUpdated: false,
+        visited: false,
       };
 
     case UPDATE_PICO_PAGE_INFO:
       return {
         ...state,
+        visited: true,
         pageInfo: payload,
       };
 

--- a/packages/integrations/selectors/picoSelector.js
+++ b/packages/integrations/selectors/picoSelector.js
@@ -13,6 +13,11 @@ export const picoContentReadySelector = createSelector(
   (branch) => maybeSelect(branch, 'contentReady')
 );
 
+export const picoVisitedSelector = createSelector(
+  picoSelector,
+  (branch) => maybeSelect(branch, 'visited')
+);
+
 export const picoPageInfoSelector = createSelector(
   picoSelector,
   (branch) => maybeSelect(branch, 'pageInfo')


### PR DESCRIPTION
## Issue(s): Relates to or closes...
N/A

## Summary: This pull request will...
* Add a flag in pico redux state to say if a call to `pico('visit')` has been made since the last navigation. This should prevent duplicate visits.
* Remove lingering outdated state values.

## Tests: I know this code works because...
I've tested locally.
