### PR TITLE
Fix duplicate instances of core-js showing up in irving bundles.

### DIFF
--- a/packages/babel-preset-irving/index.js
+++ b/packages/babel-preset-irving/index.js
@@ -13,10 +13,6 @@ module.exports = function babelPresetIrving(api) {
         targets: {
           browsers: 'last 3 versions',
         },
-        corejs: {
-          version: 3,
-        },
-        useBuiltIns: 'usage',
       };
       break;
 

--- a/packages/babel-preset-irving/package-lock.json
+++ b/packages/babel-preset-irving/package-lock.json
@@ -1241,9 +1241,9 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.5.tgz",
-      "integrity": "sha512-RMafpmrNB5E/bwdSphLr8a8++9TosnyJp98RZzI6VOx2R2CCMpsXXXRvmI700O9oEKpXdZat6oEK68/F0zjd4A==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz",
+      "integrity": "sha512-x/XYVQ1h684pp1mJwOV4CyvqZXqbc8CMsMGUnAbuc82ZCdv1U63w5RSUzgDSXQHG5Rps/kiksH6g2D5BuaKyXg==",
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
@@ -1414,9 +1414,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.1.tgz",
+      "integrity": "sha512-laz3Zx0avrw9a4QEIdmIblnVuJz8W51leY9iLThatCsFawWxC3sE4guASC78JbCin+DkwMpCdp1AVAuzL/GN7A=="
     },
     "debug": {
       "version": "4.1.1",

--- a/packages/babel-preset-irving/package.json
+++ b/packages/babel-preset-irving/package.json
@@ -17,7 +17,7 @@
     "@babel/plugin-transform-runtime": "^7.10.5",
     "@babel/preset-env": "^7.9.6",
     "@babel/preset-react": "^7.9.4",
-    "@babel/runtime-corejs3": "^7.10.5",
+    "@babel/runtime-corejs3": "~7.13.10",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-transform-globals": "^1.0.1",
     "babel-plugin-universal-import": "^4.0.2",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -7924,11 +7924,6 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
-    "core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
-    },
     "core-js-compat": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.9.1.tgz",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,6 @@
     "check-node-version": "^4.0.3",
     "classnames": "^2.2.6",
     "clean-webpack-plugin": "~3.0.0",
-    "core-js": "^3.6.5",
     "cors": "^2.8.5",
     "css-loader": "~5.0.2",
     "debug": "^4.1.1",


### PR DESCRIPTION
## Issue(s): Relates to or closes...
[**IRV-960**](https://alleyinteractive.atlassian.net/browse/IRV-960)

## Summary: This pull request will...
* Fix issue with duplicate core-js polyfills showing up in irving bundles.
* Include only polyfills that don't pollute the global scope via `@babel/plugin-transform-runtime`
* Include syntax transformations via `@babel/preset-env`

## Tests: I know this code works because...
Tested locally, will test again with alpha release.
