### PR TITLE
return early from components saga if we aren't redirecting

### DIFF
--- a/packages/core/sagas/resolveComponents.js
+++ b/packages/core/sagas/resolveComponents.js
@@ -58,8 +58,8 @@ export default function* resolveComponents() {
       context
     );
 
-    // Only redirect on client side and if there's, otherwise just receive components
-    // otherwise there's a strange flash of content.
+    // Only redirect on client side and if there's a redirect set up,
+    // otherwise just receive components. This prevents a strange flash of content before the redirect.
     if ((result.redirectTo && isNode()) || ! result.redirectTo) {
       yield put(actionReceiveComponents(result));
       return;

--- a/packages/core/sagas/resolveComponents.js
+++ b/packages/core/sagas/resolveComponents.js
@@ -58,10 +58,11 @@ export default function* resolveComponents() {
       context
     );
 
-    // Don't receive components on client side if redirecting,
-    // otherwise will result in a confusing flash of empty page content.
+    // Only redirect on client side and if there's, otherwise just receive components
+    // otherwise there's a strange flash of content.
     if ((result.redirectTo && isNode()) || ! result.redirectTo) {
       yield put(actionReceiveComponents(result));
+      return;
     }
 
     // Request needs to be redirected.


### PR DESCRIPTION
## Issue(s): Relates to or closes...
N/A

## Summary: This pull request will...
Should fix the following server-side error seen in newrelic: `Cannot set property location of#<Window> which has only a getter`

## Tests: I know this code works because...
Tested locally, will test on develop/preprod
