### PR TITLE
attempt to address issue with fetch called using URL without protocol

### DIFF
--- a/packages/core/utils/isomorphicFetch.js
+++ b/packages/core/utils/isomorphicFetch.js
@@ -1,13 +1,14 @@
 const realFetch = require('node-fetch');
+const URL = require('url-parse');
 
 module.exports = function isomorphicFetch(url, options) {
-  let newUrl = url;
+  const newUrl = URL(url);
 
-  if (/^\/\//.test(newUrl)) {
-    newUrl = `https:${newUrl}`;
+  if (! newUrl.protocol) {
+    newUrl.set('protocol', 'https');
   }
 
-  return realFetch.call(this, newUrl, options);
+  return realFetch.call(this, newUrl.toString(), options);
 };
 
 if (! global.fetch) {


### PR DESCRIPTION
## Issue(s): Relates to or closes...
https://alleyinteractive.atlassian.net/browse/LEDE-1516, maybe https://alleyinteractive.atlassian.net/browse/LEDE-1519 also

## Summary: This pull request will...
* Use the `url-parse` package to check for a protocol instead of the current less-reliable regex test

## Tests: I know this code works because...
Tested locally with the URL seemingly causing the issue in sentry.
