### PR TITLE
Add /embed/* to the WordPress proxy config

### DIFF
--- a/packages/wordpress/config/proxyPassthrough.js
+++ b/packages/wordpress/config/proxyPassthrough.js
@@ -5,6 +5,7 @@ module.exports = [
   '/wp-json/',
   '*.rss',
   '*/amp/',
+  '*/embed/',
   '*/feed/',
   '/favicon.ico',
 ];


### PR DESCRIPTION
## Issue(s): Relates to or closes...
None

## Summary: This pull request will...
Allow the `*/embed/` route to work as expected in core WordPress by proxying it.

## Tests: I know this code works because...
Tested and confirmed on a production project.