### PR TITLE
feat(a11ly): ➜ Pass aria atts and tabindex to link

### DIFF
--- a/packages/styled-components/components/link/index.jsx
+++ b/packages/styled-components/components/link/index.jsx
@@ -39,6 +39,7 @@ const Link = (props) => {
     rel,
     target,
     theme,
+    tabIndex,
   } = props;
   const {
     onClick: defaultOnClick,
@@ -71,15 +72,18 @@ const Link = (props) => {
   };
 
   const ariaProps = Object.keys(props).reduce((acc, propName) => {
-    if (!propName.includes('aria')) {
+    if (!propName.startsWith('aria')) {
       return acc;
     }
 
+    // Convert aria values to kebab case as camelCase aria key do not work.
+    const kebabAria = `aria-${propName.replace('aria', '').toLocaleLowerCase()}`;
+
     return {
       ...acc,
-      [propName]: props[propName],
+      [kebabAria]: props[propName],
     };
-  });
+  }, {});
 
   return (
     <LinkWrapper
@@ -89,6 +93,7 @@ const Link = (props) => {
       onClick={handleClick}
       rel={rel}
       target={target}
+      tabIndex={tabIndex}
     >
       {children}
     </LinkWrapper>

--- a/packages/styled-components/components/link/index.jsx
+++ b/packages/styled-components/components/link/index.jsx
@@ -76,7 +76,7 @@ const Link = (props) => {
       return acc;
     }
 
-    // Convert aria values to kebab case as camelCase aria key do not work.
+    // Convert aria values to kebab case as camelCase aria attributes do not work.
     const kebabAria = `aria-${propName.replace('aria', '').toLocaleLowerCase()}`;
 
     return {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please be sure to review the guide for [contributing to this repo](https://github.com/alleyinteractive/irving/blob/main/CONTRIBUTING.md) and be sure you are following all guidelines.
-->

## Issue(s): Relates to or closes...

<!-- Does this PR relate to or close any issues? -->

## Summary: This pull request will...

- Convert aria attributes to kebab case before spreading as camel case aria attributes are no supported.
- Add support for passing a tabindex prop.

## Tests: I know this code works because...

<!-- How will you or do you know your code works? Example: The tests you wrote, the commands you ran and their output, screenshots / videos if the pull request changes components or something user-facing. -->
