### PR TITLE
feat(commentcountstatic): add new Coral component for displaying static comment count data

### DIFF
--- a/packages/integrations/components/coral/commentCountStatic.jsx
+++ b/packages/integrations/components/coral/commentCountStatic.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const CommentCountStatic = (props) => {
+  const {
+    count,
+    countText,
+  } = props;
+
+  return (
+    <span className="coral-count">
+      <span className="coral-count-number">{count}</span>
+      <span className="coral-count-text">{countText}</span>
+    </span>
+  );
+};
+
+CommentCountStatic.defaultProps = {
+  countText: 'Comments',
+};
+
+CommentCountStatic.propTypes = {
+  count: PropTypes.number.isRequired,
+  countText: PropTypes.string,
+};
+
+export default CommentCountStatic;


### PR DESCRIPTION
## Issue(s): Relates to or closes...

N/A

## Summary: This pull request will...

* Add a new component that will render a static comment count passed to it (using markup that matches the output from the dynamic Coral comment count component)

## Tests: I know this code works because...

Tested locally, and will test in preproduction environment.