### PR TITLE
fix(commentcountstatic): add support for additional Coral config in static component

### DIFF
--- a/packages/integrations/components/coral/commentCountStatic.jsx
+++ b/packages/integrations/components/coral/commentCountStatic.jsx
@@ -3,12 +3,18 @@ import PropTypes from 'prop-types';
 
 const CommentCountStatic = (props) => {
   const {
+    articleUrl,
     count,
     countText,
+    noText,
   } = props;
 
   return (
-    <span className="coral-count">
+    <span
+      className="coral-count"
+      data-coral-url={articleUrl}
+      data-coral-notext={noText}
+    >
       <span className="coral-count-number">{count}</span>
       <span className="coral-count-text">{countText}</span>
     </span>
@@ -17,11 +23,14 @@ const CommentCountStatic = (props) => {
 
 CommentCountStatic.defaultProps = {
   countText: 'Comments',
+  noText: false,
 };
 
 CommentCountStatic.propTypes = {
+  articleUrl: PropTypes.string.isRequired,
   count: PropTypes.number.isRequired,
   countText: PropTypes.string,
+  noText: PropTypes.bool,
 };
 
 export default CommentCountStatic;


### PR DESCRIPTION
## Issue(s): Relates to or closes...

N/A

## Summary: This pull request will...

Add `articleUrl` and `noText` config to achieve full parity with the original Coral comment count component. Most notably, the `data-coral-url` attribute needs to be present, otherwise Coral assumes the canonical URL and live-updates all Coral comment counts on the page to the same comment count when a new comment is made.

## Tests: I know this code works because...
Tested locally and in preproduction environment