### PR TITLE
fix(analytics): fix [object object] ga event action

### DIFF
--- a/packages/integrations/components/pico/usePicoGTMEvents.js
+++ b/packages/integrations/components/pico/usePicoGTMEvents.js
@@ -19,11 +19,20 @@ const usePicoGTMEvents = () => {
     log.info(
       `[irving:usePicoGTMEvents] ${event.type} handler called.`,
     );
+
+    /**
+     * Pico sends a string back for event.type for every event,
+     * except for pico.user.registered which it sends {user: name@email.com}
+     * which would results in an action that is [object, object] so here we check
+     * for that case and send along "User registered" manually.
+     */
+    const action = event.type === 'pico.user.registered' ? 'User registered' : event.detail;
+
     trackEvent({
       event: event.type,
       eventContext: 'irving.integrations.pico',
       eventData: {
-        action: event.detail,
+        action,
         category: 'Pico',
         label: event.type,
       },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please be sure to review the guide for [contributing to this repo](https://github.com/alleyinteractive/irving/blob/main/CONTRIBUTING.md) and be sure you are following all guidelines.
-->

## Issue(s): Relates to or closes...

<!-- Does this PR relate to or close any issues? -->

## Summary: This pull request will...
 Pico sends a string back for event.type for every event except for pico.user.registered which it sends `{user: name@email.com}`  which would results in an action that is `[object, object]`.

This PR checks for that case and sends along a string as the event action.

## Tests: I know this code works because...

<!-- How will you or do you know your code works? Example: The tests you wrote, the commands you ran and their output, screenshots / videos if the pull request changes components or something user-facing. -->
