### PR TITLE
fix(commentcountstatic): differentiate class name for secondary Coral comment count component

### DIFF
--- a/packages/integrations/components/coral/commentCountStatic.jsx
+++ b/packages/integrations/components/coral/commentCountStatic.jsx
@@ -11,7 +11,7 @@ const CommentCountStatic = (props) => {
 
   return (
     <span
-      className="coral-count"
+      className="coral-count-static"
       data-coral-url={articleUrl}
       data-coral-notext={noText}
     >


### PR DESCRIPTION
## Issue(s): Relates to or closes...

N/A

## Summary: This pull request will...

Change the class name so that the 2 Coral comment count components are differentiated and the Coral embed does not override comment counts (`.coral-count` is a selector with significance for the embed)

## Tests: I know this code works because...

tested locally