### PR TITLE
add service aliases to docs babel config

### DIFF
--- a/docs/.storybook/babel.config.js
+++ b/docs/.storybook/babel.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const { packagesRoot } = require('./paths');
 const aliases = require(path.join(packagesRoot, 'core/config/aliases'));
+const getServiceAliases = require(path.join(packagesRoot, 'core/config/irving/getServiceAliases'));
 
 module.exports = {
   plugins: [
@@ -13,6 +14,7 @@ module.exports = {
         cwd: "packagejson",
         alias: {
           ...aliases,
+          ...getServiceAliases('web'),
           '@irvingjs/componentMap': path.resolve(
             __dirname,
             '../componentMap.js'


### PR DESCRIPTION
## Issue(s): Relates to or closes...
N/A

## Summary: This pull request will...
Add service aliases to storybook babel config via `core/config/irving/getServiceAliases`. This will prevent failed builds resulting from components using the tracking service, in particular.

## Tests: I know this code works because...
tested locally
