### PR TITLE
fix(pico): Patch race condition by making sure pico script is loaded before triggering visit

### DIFF
--- a/packages/integrations/components/pico/index.jsx
+++ b/packages/integrations/components/pico/index.jsx
@@ -62,10 +62,8 @@ const Pico = (props) => {
   );
 
   const irvingIsLoading = useLoading();
-  const {
-    scriptOnload,
-    ready: picoReady,
-  } = useSelector(picoLifecycleSelector);
+  const { ready: picoReady } = useSelector(picoLifecycleSelector);
+  const scriptLoaded = window?.Pico?.getInstance()?.scriptLoaded;
   const contentReady = useSelector(picoContentReadySelector);
   const visited = useSelector(picoVisitedSelector);
 
@@ -85,7 +83,7 @@ const Pico = (props) => {
   useEffect(() => {
     if (
       !irvingIsLoading
-      && scriptOnload
+      && scriptLoaded
       && !visited
       && (
         (contentReady && picoPageInfo.article)
@@ -98,7 +96,7 @@ const Pico = (props) => {
     }
   }, [
     irvingIsLoading,
-    scriptOnload,
+    scriptLoaded,
     contentReady,
     picoPageInfo.url,
   ]);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please be sure to review the guide for [contributing to this repo](https://github.com/alleyinteractive/irving/blob/main/CONTRIBUTING.md) and be sure you are following all guidelines.
-->

## Issue(s): Relates to or closes...

<!-- Does this PR relate to or close any issues? -->

## Summary: This pull request will...

This PR makes sure the pico gadget script is loaded before calling `window.pico('visit', {...})`.

We were waiting on a number of conditions to dispatch a page visit (`dispatchUpdatePicoPageInfo`) one of which was `pico.scriptOnLoad`.  `pico.scriptOnLoad` is fired at the very beginning of the script and not after the script is loaded creating a brief race condition between the script loading and our action running.

## Tests: I know this code works because...

<!-- How will you or do you know your code works? Example: The tests you wrote, the commands you ran and their output, screenshots / videos if the pull request changes components or something user-facing. -->
