### PR TITLE
fix(coral): remove base64url encoding to base64 encoding conversion on Coral JWT token

### DIFF
--- a/packages/integrations/components/coral/index.jsx
+++ b/packages/integrations/components/coral/index.jsx
@@ -44,29 +44,6 @@ const CoralEmbed = ({
   // https://reactjs.org/docs/hooks-rules.html
   const shouldPurgeUser = useSelector(purgeSelector);
 
-  /**
-   * Decode the payload of a JWT token so it becomes a base64 encoded string.
-   *
-   * This fixes an issue with the way Coral decodes JWT access token payloads
-   * using `atob()`, which assumes the string is base64. When URL safe string
-   * replacements for `+` and `/` are included, Coral will not be able to
-   * decode the string properly and fail to log in the user.
-   *
-   * @see https://stackoverflow.com/questions/49082844/how-could-firebase-send-a-jwt-token-which-payload-contains-an-underscore-charact
-   *
-   * @param string token A base64url encoded JWT token.
-   * @returns string A JWT token with a base64 payload.
-   */
-  const base64UrlDecodeJWTPayload = (token) => {
-    // Split the token into parts so we can decode the payload.
-    const parts = token.split('.');
-
-    // Replace URL encoded characters with the expected base64 alternatives.
-    parts[1] = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-
-    return parts.join('.');
-  };
-
   useEffect(() => {
     if (window.Coral) {
       embed = window.Coral.createStreamEmbed({
@@ -79,7 +56,7 @@ const CoralEmbed = ({
 
       if (accessToken) {
         // Login the user if an access token exists.
-        embed.login(base64UrlDecodeJWTPayload(accessToken));
+        embed.login(accessToken);
         // Register the login in the state tree.
         dispatchLogin();
       }


### PR DESCRIPTION
## Issue(s): Relates to or closes...

N/A

## Summary: This pull request will...

Remove an earlier fix that converted the JWT token payload for Coral from base64url to base64. While this skirted the `atob()` error, it resulted in malformed tokens in some cases which would cause the Coral embed to die. The JWT spec calls for base64url, and Coral fixed the underlying issue in the Talk repo [here](https://github.com/coralproject/talk/pull/3206). Note that this requires you be on 6.3.7 or later of Coral for compatibility. 

## Tests: I know this code works because...

Tested locally and in develop environments
