### PR TITLE
fix scriptLoaded flag to use pico lifecycle instead of accessing Pico object directly

### DIFF
--- a/packages/integrations/components/pico/index.jsx
+++ b/packages/integrations/components/pico/index.jsx
@@ -62,11 +62,12 @@ const Pico = (props) => {
   );
 
   const irvingIsLoading = useLoading();
-  const { ready: picoReady } = useSelector(picoLifecycleSelector);
+  const {
+    ready: picoReady,
+    scriptOnload: scriptLoaded,
+  } = useSelector(picoLifecycleSelector);
   const contentReady = useSelector(picoContentReadySelector);
   const visited = useSelector(picoVisitedSelector);
-  const picoInstance = window?.Pico?.instance || false;
-  const scriptLoaded = picoInstance ? window?.Pico?.getInstance() : false;
 
   // Add lifecycle listeners.
   usePicoEventListeners();
@@ -97,7 +98,6 @@ const Pico = (props) => {
     }
   }, [
     irvingIsLoading,
-    picoInstance,
     contentReady,
     picoPageInfo.url,
     scriptLoaded,
@@ -118,9 +118,11 @@ Pico.defaultProps = {
   widgetUrl: 'https://gadget.pico.tools',
 };
 
+/* eslint-disable react/forbid-prop-types */
 Pico.propTypes = {
   pageInfo: PropTypes.shape({
     article: PropTypes.bool,
+    breakSelector: PropTypes.string,
     postId: PropTypes.number,
     postType: PropTypes.string,
     resourceRef: PropTypes.string,


### PR DESCRIPTION
## Issue(s): Relates to or closes...
https://alleyinteractive.atlassian.net/browse/LEDE-1924

## Summary: This pull request will...
* Rework code intended to prevent pico's `'Local storage not available'` error message to use the Pico lifecycle value instead of accessing the global `Pico` object directly.
* hoping this works better as it avoids calling `window.Pico.getInstance()` which, if called too early, seems to throw that local storage error.

## Tests: I know this code works because...
* Tested locally (so far)
